### PR TITLE
Add sample inventory CSV and handle fallback

### DIFF
--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -116,15 +116,21 @@ async function loadInventory() {
         return inventory;
     } catch (error) {
         console.error('Error loading inventory from API:', error);
-        // Fallback to CSV approach
+        // If API fails, attempt to load from the local CSV sample
         return loadInventoryFromCSV();
     }
 }
 
 // Fallback CSV loading method
+// Attempts to read `sample_inventory_data.csv` from the project root
+// so the dashboard still works during local development.
 async function loadInventoryFromCSV() {
     try {
         const response = await fetch('/sample_inventory_data.csv');
+        if (!response.ok) {
+            console.warn('Sample inventory CSV not found');
+            return [];
+        }
         const csvText = await response.text();
         
         const lines = csvText.split('\n').slice(1);

--- a/sample_inventory_data.csv
+++ b/sample_inventory_data.csv
@@ -1,0 +1,6 @@
+car_id,model,sales_price
+2001,Honda Civic 2024,290596.69
+2002,Volkswagen Jetta 2024,291786.61
+2003,Hyundai Elantra 2022,430401.55
+2004,Kia Optima 2024,402160.23
+2005,Ford Focus 2024,282354.12


### PR DESCRIPTION
## Summary
- add sample inventory data CSV at project root for demo mode
- update inventory CSV loader in `main.js` to check for missing file
- document fallback logic in comments

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685452d1a98c8322b4986b7d4aa00ff4