### PR TITLE
Fix search logic and add amortization table

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -717,4 +717,46 @@ body {
     background: #dbeafe;
     border: 1px solid #3b82f6;
     color: #1e40af;
-} 
+}
+
+/* Amortization modal */
+.modal {
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background: rgba(0,0,0,0.5);
+}
+
+.modal-content {
+    background: white;
+    margin: 5% auto;
+    padding: 20px;
+    border-radius: 8px;
+    width: 90%;
+    max-width: 600px;
+}
+
+.modal-close {
+    float: right;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+.amort-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+}
+.amort-table th, .amort-table td {
+    border: 1px solid #e5e7eb;
+    padding: 4px 6px;
+    text-align: right;
+}
+.amort-table th {
+    background: #f3f4f6;
+    text-align: center;
+}

--- a/app/templates/customer_view.html
+++ b/app/templates/customer_view.html
@@ -430,6 +430,7 @@
         function createEnhancedOfferCard(offer) {
             const subsidyLevel = getSubsidyLevel(offer.fees_applied);
             const tierClass = 'tier-' + offer.tier.toLowerCase().replace(' ', '-');
+            const encoded = encodeURIComponent(JSON.stringify(offer));
             
             return `
                 <div class="offer-card-enhanced" onclick="toggleOfferDetails(this)">
@@ -464,6 +465,9 @@
                             <div style="font-size: 12px; color: #6b7280;">Car Price</div>
                             <div style="font-size: 16px; font-weight: 600;">$${offer.new_car_price.toLocaleString('en-US', {maximumFractionDigits: 0})}</div>
                         </div>
+                    </div>
+                    <div style="margin:10px 0;text-align:right;">
+                        <button class="btn-secondary" data-offer="${encoded}" onclick="event.stopPropagation(); openAmortization(this)">View Amortization</button>
                     </div>
                     
                     <div class="offer-details" style="display: none;">
@@ -553,7 +557,12 @@
             }
             return { label: 'Custom', class: 'subsidy-phase1' };
         }
-        
+
+        function openAmortization(button) {
+            const offer = JSON.parse(decodeURIComponent(button.dataset.offer));
+            viewAmortizationTable(offer);
+        }
+
         function toggleOfferDetails(card) {
             const details = card.querySelector('.offer-details');
             const isExpanded = details.style.display === 'block';

--- a/core/calculator.py
+++ b/core/calculator.py
@@ -1,6 +1,7 @@
 import numpy_financial as npf
 from .config import IVA_RATE
 
+
 def calculate_final_npv(loan_amount, interest_rate, term_months):
     """
     Calculates the Net Present Value of the interest income for the loan,
@@ -10,7 +11,7 @@ def calculate_final_npv(loan_amount, interest_rate, term_months):
     """
     if loan_amount <= 0:
         return 0.0
-    
+
     # Generate the cash-flow of interest income for each month.
     # `numpy_financial.ipmt` returns a POSITIVE value when the present value
     # (`pv`) is passed in as a negative number (i.e. cash outflow for the
@@ -22,7 +23,68 @@ def calculate_final_npv(loan_amount, interest_rate, term_months):
         npf.ipmt(tasa_mensual_sin_iva, period, term_months, -loan_amount)
         for period in range(1, term_months + 1)
     ]
-    
+
     # Calculate NPV using the same monthly rate as the discount rate
     npv = npf.npv(tasa_mensual_sin_iva, [0] + interest_payments)
     return npv
+
+
+def generate_amortization_table(offer_details: dict) -> list[dict]:
+    """Generate month-by-month amortization table for a single offer."""
+    loan_amount = offer_details.get("loan_amount", 0.0)
+    term = int(offer_details.get("term", 0))
+    rate = offer_details.get("interest_rate", 0.0)
+
+    service_fee = offer_details.get("service_fee_amount", 0.0)
+    kavak_total = offer_details.get("kavak_total_amount", 0.0)
+    insurance_amt = offer_details.get("insurance_amount", 0.0)
+    gps_fee = offer_details.get("fees_applied", {}).get("fixed_fee", 0.0) * IVA_RATE
+
+    monthly_rate_i = rate / 12
+    monthly_rate_p = (rate * IVA_RATE) / 12
+
+    financed_main = loan_amount + service_fee + kavak_total
+
+    balance_main = financed_main
+    balance_ins = insurance_amt
+
+    table = []
+    for month in range(1, term + 1):
+        beginning_balance = balance_main + (balance_ins if month <= 12 else 0)
+
+        principal_main = abs(npf.ppmt(monthly_rate_p, month, term, -financed_main))
+        interest_main = (
+            abs(npf.ipmt(monthly_rate_i, month, term, -financed_main)) * IVA_RATE
+        )
+
+        if month <= 12 and insurance_amt > 0:
+            principal_ins = abs(npf.ppmt(monthly_rate_p, month, 12, -insurance_amt))
+            interest_ins = (
+                abs(npf.ipmt(monthly_rate_i, month, 12, -insurance_amt)) * IVA_RATE
+            )
+        else:
+            principal_ins = 0.0
+            interest_ins = 0.0
+
+        payment = (
+            principal_main + interest_main + principal_ins + interest_ins + gps_fee
+        )
+
+        balance_main -= principal_main
+        if month <= 12:
+            balance_ins -= principal_ins
+
+        ending_balance = balance_main + (balance_ins if month < 12 else 0)
+
+        table.append(
+            {
+                "month": month,
+                "beginning_balance": beginning_balance,
+                "payment": payment,
+                "principal": principal_main + principal_ins,
+                "interest": interest_main + interest_ins,
+                "ending_balance": ending_balance,
+            }
+        )
+
+    return table

--- a/core/engine.py
+++ b/core/engine.py
@@ -9,286 +9,428 @@ from .config import (
     PAYMENT_DELTA_TIERS,
     IVA_RATE,
     GPS_INSTALLATION_FEE,
-    INSURANCE_TABLE
+    INSURANCE_TABLE,
 )
 
 # Load config tables on import
 INTEREST_RATE_TABLE, DOWN_PAYMENT_TABLE = get_hardcoded_financial_parameters()
 
+
 class TradeUpEngine:
     def __init__(self, config=None):
         self.config = config or {}
-        
+
     def generate_offers(self, customer: dict, inventory: pd.DataFrame):
         """Main entry point for offer generation."""
         return run_engine_for_customer(customer, inventory, self.config)
-        
+
     def update_config(self, new_config: dict):
         """Update engine configuration."""
         self.config.update(new_config)
-        
+
     @property
     def current_config(self):
         """Get current engine configuration."""
         return self.config.copy()
 
-def run_engine_for_customer(customer: dict, inventory: pd.DataFrame, engine_config: dict):
+
+def run_engine_for_customer(
+    customer: dict, inventory: pd.DataFrame, engine_config: dict
+):
     """
     Main orchestrator function. Generates all possible offers for a single customer.
     Supports: default hierarchical search, custom parameter mode, and range-based optimization.
     """
     print(f"--- Running engine for customer: {customer.get('customer_id')} ---")
-    
+
     try:
-        current_monthly_payment = customer['current_monthly_payment']
+        current_monthly_payment = customer["current_monthly_payment"]
         # Engine is responsible for interest rate lookup from risk profile
-        interest_rate = INTEREST_RATE_TABLE.loc[customer['risk_profile_name']]
+        interest_rate = INTEREST_RATE_TABLE.loc[customer["risk_profile_name"]]
     except KeyError as e:
         print(f"Error: Missing key in customer data or invalid risk profile - {e}")
         return pd.DataFrame()
 
     # Determine payment delta tiers to use
-    if 'payment_delta_tiers' in engine_config:
-        custom_tiers = engine_config['payment_delta_tiers']
+    if "payment_delta_tiers" in engine_config:
+        custom_tiers = engine_config["payment_delta_tiers"]
         payment_delta_tiers = {
-            'Refresh': tuple(custom_tiers.get('refresh', PAYMENT_DELTA_TIERS['Refresh'])),
-            'Upgrade': tuple(custom_tiers.get('upgrade', PAYMENT_DELTA_TIERS['Upgrade'])),
-            'Max Upgrade': tuple(custom_tiers.get('max_upgrade', PAYMENT_DELTA_TIERS['Max Upgrade']))
+            "Refresh": tuple(
+                custom_tiers.get("refresh", PAYMENT_DELTA_TIERS["Refresh"])
+            ),
+            "Upgrade": tuple(
+                custom_tiers.get("upgrade", PAYMENT_DELTA_TIERS["Upgrade"])
+            ),
+            "Max Upgrade": tuple(
+                custom_tiers.get("max_upgrade", PAYMENT_DELTA_TIERS["Max Upgrade"])
+            ),
         }
         print(f"🎯 Using custom payment tiers: {payment_delta_tiers}")
     else:
         payment_delta_tiers = PAYMENT_DELTA_TIERS
 
     # Check engine mode
-    use_custom_params = engine_config.get('use_custom_params', False)
-    use_range_optimization = engine_config.get('use_range_optimization', False)
-    
+    use_custom_params = engine_config.get("use_custom_params", False)
+    use_range_optimization = engine_config.get("use_range_optimization", False)
+
     if use_range_optimization:
-        print("🎯 RANGE OPTIMIZATION MODE: Using parameter ranges with NPV filtering...")
-        return _run_range_optimization_search(customer, inventory, interest_rate, engine_config, current_monthly_payment, payment_delta_tiers)
+        print(
+            "🎯 RANGE OPTIMIZATION MODE: Using parameter ranges with NPV filtering..."
+        )
+        return _run_range_optimization_search(
+            customer,
+            inventory,
+            interest_rate,
+            engine_config,
+            current_monthly_payment,
+            payment_delta_tiers,
+        )
     elif use_custom_params:
         print("🔧 CUSTOM PARAMETER MODE: Using user-defined configuration...")
-        return _run_custom_parameter_search(customer, inventory, interest_rate, engine_config, current_monthly_payment, payment_delta_tiers)
+        return _run_custom_parameter_search(
+            customer,
+            inventory,
+            interest_rate,
+            engine_config,
+            current_monthly_payment,
+            payment_delta_tiers,
+        )
     else:
         print("⚙️ DEFAULT MODE: Using hierarchical subsidy search...")
-        return _run_default_hierarchical_search(customer, inventory, interest_rate, engine_config, current_monthly_payment, payment_delta_tiers)
+        return _run_default_hierarchical_search(
+            customer,
+            inventory,
+            interest_rate,
+            engine_config,
+            current_monthly_payment,
+            payment_delta_tiers,
+        )
 
-def _run_default_hierarchical_search(customer, inventory, interest_rate, engine_config, current_monthly_payment, payment_delta_tiers):
+
+def _run_default_hierarchical_search(
+    customer,
+    inventory,
+    interest_rate,
+    engine_config,
+    current_monthly_payment,
+    payment_delta_tiers,
+):
     """Original hierarchical search with hardcoded subsidy levers and NPV filtering."""
-    all_offers = []
-    
+
     # Extract NPV threshold for filtering
-    min_npv_threshold = engine_config.get('min_npv_threshold', 5000.0)
-    
+    min_npv_threshold = engine_config.get("min_npv_threshold", 5000.0)
+
     # --- PHASE 1: Search with NO Subsidy (Max Profit) ---
     print("PHASE 1: Searching for offers with MAX PROFIT...")
     phase_1_fees = DEFAULT_FEES.copy()
-    phase_1_fees['cac_bonus'] = 0  # Ensure no bonus in phase 1
-    if not engine_config.get('include_kavak_total', True):
-        phase_1_fees['kavak_total_amount'] = 0
-    
-    print(f"   Using fees: Service={phase_1_fees['service_fee_pct']*100}%, CXA={phase_1_fees['cxa_pct']*100}%, CAC={phase_1_fees['cac_bonus']}")
-    
-    # Run the ENTIRE Phase 1 search across all terms and cars with NPV filtering
-    phase_1_offers = _run_search_phase_with_npv_filter(customer, inventory, interest_rate, phase_1_fees, min_npv_threshold, payment_delta_tiers)
-    all_offers.extend(phase_1_offers)
+    phase_1_fees["cac_bonus"] = 0  # Ensure no bonus in phase 1
+    if not engine_config.get("include_kavak_total", True):
+        phase_1_fees["kavak_total_amount"] = 0
 
-    # If Phase 1 found any offers, STOP and return results
+    print(
+        f"   Using fees: Service={phase_1_fees['service_fee_pct']*100}%, CXA={phase_1_fees['cxa_pct']*100}%, CAC={phase_1_fees['cac_bonus']}"
+    )
+
+    phase_1_offers = _run_search_phase_with_npv_filter(
+        customer,
+        inventory,
+        interest_rate,
+        phase_1_fees,
+        min_npv_threshold,
+        payment_delta_tiers,
+    )
+
     if phase_1_offers:
         print(f"PHASE 1 COMPLETE: Found {len(phase_1_offers)} offers. Stopping search.")
-        return _finalize_offers_dataframe(all_offers, current_monthly_payment, payment_delta_tiers)
+        return _finalize_offers_dataframe(
+            phase_1_offers, current_monthly_payment, payment_delta_tiers
+        )
 
     # --- PHASE 2: Search WITH Subsidy (Concession) - EXHAUSTIVE ---
     print("PHASE 2: No offers found in Phase 1. Running EXHAUSTIVE subsidy search...")
-    
+
     # Level 1: Service Fee = 0
     print("Phase 2 - Level 1: Reducing Service Fee to 0...")
     fees_level_1 = DEFAULT_FEES.copy()
-    fees_level_1['service_fee_pct'] = 0
-    fees_level_1['cac_bonus'] = 0  # No CAC bonus yet
-    if not engine_config.get('include_kavak_total', True):
-        fees_level_1['kavak_total_amount'] = 0
-    level_1_offers = _run_search_phase_with_npv_filter(customer, inventory, interest_rate, fees_level_1, min_npv_threshold, payment_delta_tiers)
-    all_offers.extend(level_1_offers)
-    
+    fees_level_1["service_fee_pct"] = 0
+    fees_level_1["cac_bonus"] = 0
+    if not engine_config.get("include_kavak_total", True):
+        fees_level_1["kavak_total_amount"] = 0
+    level_1_offers = _run_search_phase_with_npv_filter(
+        customer,
+        inventory,
+        interest_rate,
+        fees_level_1,
+        min_npv_threshold,
+        payment_delta_tiers,
+    )
+    if level_1_offers:
+        print(f"Level 1 COMPLETE: Found {len(level_1_offers)} offers. Stopping search.")
+        return _finalize_offers_dataframe(
+            level_1_offers, current_monthly_payment, payment_delta_tiers
+        )
+
     # Level 2: Service Fee = 0 AND CAC Bonus applied
     print("Phase 2 - Level 2: Adding CAC Bonus...")
     fees_level_2 = fees_level_1.copy()
-    fees_level_2['cac_bonus'] = MAX_CAC_BONUS
-    level_2_offers = _run_search_phase_with_npv_filter(customer, inventory, interest_rate, fees_level_2, min_npv_threshold, payment_delta_tiers)
-    all_offers.extend(level_2_offers)
-    
+    fees_level_2["cac_bonus"] = MAX_CAC_BONUS
+    level_2_offers = _run_search_phase_with_npv_filter(
+        customer,
+        inventory,
+        interest_rate,
+        fees_level_2,
+        min_npv_threshold,
+        payment_delta_tiers,
+    )
+    if level_2_offers:
+        print(f"Level 2 COMPLETE: Found {len(level_2_offers)} offers. Stopping search.")
+        return _finalize_offers_dataframe(
+            level_2_offers, current_monthly_payment, payment_delta_tiers
+        )
+
     # Level 3: All previous subsidies AND CXA = 0
     print("Phase 2 - Level 3: Reducing CXA to 0...")
     fees_level_3 = fees_level_2.copy()
-    fees_level_3['cxa_pct'] = 0
-    level_3_offers = _run_search_phase_with_npv_filter(customer, inventory, interest_rate, fees_level_3, min_npv_threshold, payment_delta_tiers)
-    all_offers.extend(level_3_offers)
-    
-    print(f"PHASE 2 COMPLETE: Found {len(all_offers)} total offers across all subsidy levels.")
+    fees_level_3["cxa_pct"] = 0
+    level_3_offers = _run_search_phase_with_npv_filter(
+        customer,
+        inventory,
+        interest_rate,
+        fees_level_3,
+        min_npv_threshold,
+        payment_delta_tiers,
+    )
+    if level_3_offers:
+        print(f"Level 3 COMPLETE: Found {len(level_3_offers)} offers. Stopping search.")
+        return _finalize_offers_dataframe(
+            level_3_offers, current_monthly_payment, payment_delta_tiers
+        )
+
+    print("PHASE 2 COMPLETE: No valid offers found in any subsidy level.")
     print(f"NPV filtering applied: Min {min_npv_threshold:,.0f} MXN")
-    
-    # Remove duplicate offers (same car might be viable at multiple subsidy levels)
-    if all_offers:
-        offers_df = pd.DataFrame(all_offers)
-        offers_df.drop_duplicates(subset=['car_id', 'term'], inplace=True)
-        return _finalize_offers_dataframe(offers_df.to_dict(orient='records'), current_monthly_payment, payment_delta_tiers)
-        
+
     return pd.DataFrame()
 
-def _run_range_optimization_search(customer, inventory, interest_rate, engine_config, current_monthly_payment, payment_delta_tiers):
+
+def _run_range_optimization_search(
+    customer,
+    inventory,
+    interest_rate,
+    engine_config,
+    current_monthly_payment,
+    payment_delta_tiers,
+):
     """
     Range-based optimization search with extreme granularity and NPV filtering.
     Generates all parameter combinations within specified ranges for maximum flexibility.
     """
     import itertools
-    
+
     all_offers = []
-    
+
     # Extract parameter ranges from config (with defaults)
-    service_fee_range = engine_config.get('service_fee_range', (0.0, 5.0))
-    cxa_range = engine_config.get('cxa_range', (0.0, 4.0))
-    cac_bonus_range = engine_config.get('cac_bonus_range', (0, 10000))
-    
+    service_fee_range = engine_config.get("service_fee_range", (0.0, 5.0))
+    cxa_range = engine_config.get("cxa_range", (0.0, 4.0))
+    cac_bonus_range = engine_config.get("cac_bonus_range", (0, 10000))
+
     # Extract granularity settings (basis point precision)
-    service_fee_step = engine_config.get('service_fee_step', 0.01)  # 1 basis point
-    cxa_step = engine_config.get('cxa_step', 0.01)  # 1 basis point
-    cac_bonus_step = engine_config.get('cac_bonus_step', 100)  # 100 MXN steps
-    
+    service_fee_step = engine_config.get("service_fee_step", 0.01)  # 1 basis point
+    cxa_step = engine_config.get("cxa_step", 0.01)  # 1 basis point
+    cac_bonus_step = engine_config.get("cac_bonus_step", 100)  # 100 MXN steps
+
     # Extract NPV filtering threshold
-    min_npv_threshold = engine_config.get('min_npv_threshold', 5000.0)
-    
+    min_npv_threshold = engine_config.get("min_npv_threshold", 5000.0)
+
     # EARLY STOPPING: Add max combinations limit
-    max_combinations_to_test = engine_config.get('max_combinations_to_test', 1000)  # Default: test max 1000 combinations
-    early_stop_on_offers = engine_config.get('early_stop_on_offers', 100)  # Stop if we find 100 valid offers
-    
+    max_combinations_to_test = engine_config.get(
+        "max_combinations_to_test", 1000
+    )  # Default: test max 1000 combinations
+    early_stop_on_offers = engine_config.get(
+        "early_stop_on_offers", 100
+    )  # Stop if we find 100 valid offers
+
     # Generate parameter combinations
-    service_fee_values = [round(x, 4) for x in _generate_range(service_fee_range[0], service_fee_range[1], service_fee_step)]
-    cxa_values = [round(x, 4) for x in _generate_range(cxa_range[0], cxa_range[1], cxa_step)]
-    cac_bonus_values = list(range(int(cac_bonus_range[0]), int(cac_bonus_range[1]) + 1, int(cac_bonus_step)))
-    
+    service_fee_values = [
+        round(x, 4)
+        for x in _generate_range(
+            service_fee_range[0], service_fee_range[1], service_fee_step
+        )
+    ]
+    cxa_values = [
+        round(x, 4) for x in _generate_range(cxa_range[0], cxa_range[1], cxa_step)
+    ]
+    cac_bonus_values = list(
+        range(int(cac_bonus_range[0]), int(cac_bonus_range[1]) + 1, int(cac_bonus_step))
+    )
+
     print(f"🎯 Parameter ranges:")
-    print(f"   Service Fee: {len(service_fee_values)} values from {service_fee_range[0]}% to {service_fee_range[1]}%")
+    print(
+        f"   Service Fee: {len(service_fee_values)} values from {service_fee_range[0]}% to {service_fee_range[1]}%"
+    )
     print(f"   CXA: {len(cxa_values)} values from {cxa_range[0]}% to {cxa_range[1]}%")
-    print(f"   CAC Bonus: {len(cac_bonus_values)} values from {cac_bonus_range[0]} to {cac_bonus_range[1]} MXN")
+    print(
+        f"   CAC Bonus: {len(cac_bonus_values)} values from {cac_bonus_range[0]} to {cac_bonus_range[1]} MXN"
+    )
     print(f"   Min NPV Threshold: {min_npv_threshold:,.0f} MXN")
-    
-    total_combinations = len(service_fee_values) * len(cxa_values) * len(cac_bonus_values)
+
+    total_combinations = (
+        len(service_fee_values) * len(cxa_values) * len(cac_bonus_values)
+    )
     print(f"   Total parameter combinations: {total_combinations:,}")
-    print(f"   ⚡ EARLY STOPPING: Will test max {max_combinations_to_test} combinations or until {early_stop_on_offers} offers found")
-    
+    print(
+        f"   ⚡ EARLY STOPPING: Will test max {max_combinations_to_test} combinations or until {early_stop_on_offers} offers found"
+    )
+
     # Use provided payment delta tiers
     tiers = payment_delta_tiers
-    
+
     # Search through all parameter combinations
     valid_offers_count = 0
     combinations_tested = 0
-    
+
     # EARLY STOPPING: Create parameter iterator for controlled iteration
     param_iterator = itertools.product(service_fee_values, cxa_values, cac_bonus_values)
-    
+
     for service_fee_pct, cxa_pct, cac_bonus in param_iterator:
         combinations_tested += 1
-        
+
         # Build fee configuration for this combination
         fees_config = {
-            'service_fee_pct': service_fee_pct / 100,  # Convert percentage to decimal
-            'cxa_pct': cxa_pct / 100,  # Convert percentage to decimal
-            'cac_bonus': cac_bonus,
-            'kavak_total_amount': DEFAULT_FEES['kavak_total_amount'] if engine_config.get('include_kavak_total', True) else 0,
-            'insurance_amount': engine_config.get('insurance_amount', DEFAULT_FEES['insurance_amount']),
-            'fixed_fee': engine_config.get('gps_fee', DEFAULT_FEES['fixed_fee'])
+            "service_fee_pct": service_fee_pct / 100,  # Convert percentage to decimal
+            "cxa_pct": cxa_pct / 100,  # Convert percentage to decimal
+            "cac_bonus": cac_bonus,
+            "kavak_total_amount": (
+                DEFAULT_FEES["kavak_total_amount"]
+                if engine_config.get("include_kavak_total", True)
+                else 0
+            ),
+            "insurance_amount": engine_config.get(
+                "insurance_amount", DEFAULT_FEES["insurance_amount"]
+            ),
+            "fixed_fee": engine_config.get("gps_fee", DEFAULT_FEES["fixed_fee"]),
         }
-        
+
         # Run search phase with this parameter combination
         combo_offers = _run_search_phase_with_npv_filter(
             customer, inventory, interest_rate, fees_config, min_npv_threshold, tiers
         )
-        
+
         for offer in combo_offers:
             # Add parameter metadata to each offer
-            offer['parameter_combination'] = {
-                'service_fee_pct': service_fee_pct,
-                'cxa_pct': cxa_pct,
-                'cac_bonus': cac_bonus
+            offer["parameter_combination"] = {
+                "service_fee_pct": service_fee_pct,
+                "cxa_pct": cxa_pct,
+                "cac_bonus": cac_bonus,
             }
             valid_offers_count += 1
-        
+
         all_offers.extend(combo_offers)
-        
+
         # EARLY STOPPING CONDITIONS
         if combinations_tested >= max_combinations_to_test:
-            print(f"   ⚡ Early stopping: Reached max combinations limit ({max_combinations_to_test})")
+            print(
+                f"   ⚡ Early stopping: Reached max combinations limit ({max_combinations_to_test})"
+            )
             break
-            
+
         if valid_offers_count >= early_stop_on_offers:
-            print(f"   ⚡ Early stopping: Found enough offers ({valid_offers_count} >= {early_stop_on_offers})")
+            print(
+                f"   ⚡ Early stopping: Found enough offers ({valid_offers_count} >= {early_stop_on_offers})"
+            )
             break
-    
+
     print(f"🎯 RANGE OPTIMIZATION COMPLETE:")
     print(f"   Combinations tested: {combinations_tested}/{total_combinations}")
     print(f"   Valid offers found: {valid_offers_count:,}")
     print(f"   NPV filtering applied: Min {min_npv_threshold:,.0f} MXN")
-    
+
     if all_offers:
         # Remove duplicates and rank by NPV within tiers
-        return _finalize_optimized_offers_dataframe(all_offers, current_monthly_payment, engine_config, tiers)
-    
+        return _finalize_optimized_offers_dataframe(
+            all_offers, current_monthly_payment, engine_config, tiers
+        )
+
     return pd.DataFrame()
 
-def _run_custom_parameter_search(customer, inventory, interest_rate, engine_config, current_monthly_payment, payment_delta_tiers):
+
+def _run_custom_parameter_search(
+    customer,
+    inventory,
+    interest_rate,
+    engine_config,
+    current_monthly_payment,
+    payment_delta_tiers,
+):
     """Custom parameter mode using user-defined fee structure."""
     all_offers = []
-    
+
     # Build custom fee structure from engine_config
     custom_fees = {
-        'service_fee_pct': engine_config.get('service_fee_pct', DEFAULT_FEES['service_fee_pct']),
-        'cxa_pct': engine_config.get('cxa_pct', DEFAULT_FEES['cxa_pct']),
-        'cac_bonus': engine_config.get('cac_bonus', DEFAULT_FEES['cac_bonus']),
-        'kavak_total_amount': DEFAULT_FEES['kavak_total_amount'] if engine_config.get('include_kavak_total', True) else 0,
-        'insurance_amount': engine_config.get('insurance_amount', DEFAULT_FEES['insurance_amount']),
-        'fixed_fee': engine_config.get('gps_fee', DEFAULT_FEES['fixed_fee'])
+        "service_fee_pct": engine_config.get(
+            "service_fee_pct", DEFAULT_FEES["service_fee_pct"]
+        ),
+        "cxa_pct": engine_config.get("cxa_pct", DEFAULT_FEES["cxa_pct"]),
+        "cac_bonus": engine_config.get("cac_bonus", DEFAULT_FEES["cac_bonus"]),
+        "kavak_total_amount": (
+            DEFAULT_FEES["kavak_total_amount"]
+            if engine_config.get("include_kavak_total", True)
+            else 0
+        ),
+        "insurance_amount": engine_config.get(
+            "insurance_amount", DEFAULT_FEES["insurance_amount"]
+        ),
+        "fixed_fee": engine_config.get("gps_fee", DEFAULT_FEES["fixed_fee"]),
     }
-    
+
     print(f"🔧 Using custom fees: {custom_fees}")
-    
+
     tiers = payment_delta_tiers
-    
+
     # Extract NPV threshold for filtering
-    min_npv_threshold = engine_config.get('min_npv_threshold', 5000.0)
-    
+    min_npv_threshold = engine_config.get("min_npv_threshold", 5000.0)
+
     # Run single search phase with custom parameters and NPV filtering
-    custom_offers = _run_search_phase_with_npv_filter(customer, inventory, interest_rate, custom_fees, min_npv_threshold, tiers)
+    custom_offers = _run_search_phase_with_npv_filter(
+        customer, inventory, interest_rate, custom_fees, min_npv_threshold, tiers
+    )
     all_offers.extend(custom_offers)
-    
-    print(f"🔧 CUSTOM SEARCH COMPLETE: Found {len(all_offers)} offers with custom parameters.")
-    
+
+    print(
+        f"🔧 CUSTOM SEARCH COMPLETE: Found {len(all_offers)} offers with custom parameters."
+    )
+
     if all_offers:
         return _finalize_offers_dataframe(all_offers, current_monthly_payment, tiers)
-    
+
     return pd.DataFrame()
 
 
-def _run_search_phase(customer, inventory, interest_rate, fees_config, payment_delta_tiers):
+def _run_search_phase(
+    customer, inventory, interest_rate, fees_config, payment_delta_tiers
+):
     """Helper function to run the search for a given fee configuration."""
     found_offers = []
     for car_index, car in inventory.iterrows():
         for term in TERM_SEARCH_ORDER:
-            offer = _generate_single_offer(customer, car, term, interest_rate, fees_config, payment_delta_tiers)
+            offer = _generate_single_offer(
+                customer, car, term, interest_rate, fees_config, payment_delta_tiers
+            )
             if offer:
                 found_offers.append(offer)
     return found_offers
 
 
-def _generate_single_offer(customer, car, term, interest_rate, fees_config, payment_delta_tiers):
+def _generate_single_offer(
+    customer, car, term, interest_rate, fees_config, payment_delta_tiers
+):
     """Generate a single offer following the final MVP specification."""
     # 1. Hard Filter: Price must exceed current car price
-    if car['sales_price'] <= customer['current_car_price']:
+    if car["sales_price"] <= customer["current_car_price"]:
         return None
 
     # 2. Resolve CXA circular dependency including GPS installation fee
-    cxa_pct = fees_config.get('cxa_pct', 0)
-    cac_bonus = fees_config.get('cac_bonus', 0)
+    cxa_pct = fees_config.get("cxa_pct", 0)
+    cac_bonus = fees_config.get("cac_bonus", 0)
     gps_install_with_iva = GPS_INSTALLATION_FEE * IVA_RATE
 
     denominator = 1 - cxa_pct
@@ -296,7 +438,10 @@ def _generate_single_offer(customer, car, term, interest_rate, fees_config, paym
         return None
 
     loan_amount_needed = (
-        car['sales_price'] - customer['vehicle_equity'] - cac_bonus + gps_install_with_iva
+        car["sales_price"]
+        - customer["vehicle_equity"]
+        - cac_bonus
+        + gps_install_with_iva
     ) / denominator
 
     if loan_amount_needed <= 0:
@@ -304,20 +449,20 @@ def _generate_single_offer(customer, car, term, interest_rate, fees_config, paym
 
     # 3. Component amounts
     cxa_amount = loan_amount_needed * cxa_pct
-    service_fee_amt = car['sales_price'] * fees_config.get('service_fee_pct', 0)
-    kavak_total_amt = fees_config.get('kavak_total_amount', 0)
+    service_fee_amt = car["sales_price"] * fees_config.get("service_fee_pct", 0)
+    kavak_total_amt = fees_config.get("kavak_total_amount", 0)
     insurance_amt = INSURANCE_TABLE.get(
-        customer['risk_profile_name'], DEFAULT_FEES['insurance_amount']
+        customer["risk_profile_name"], DEFAULT_FEES["insurance_amount"]
     )
 
     # 4. Effective equity calculation
     effective_equity = (
-        customer['vehicle_equity'] + cac_bonus - cxa_amount - gps_install_with_iva
+        customer["vehicle_equity"] + cac_bonus - cxa_amount - gps_install_with_iva
     )
 
     # 5. Down payment check
-    required_dp_pct = DOWN_PAYMENT_TABLE.loc[customer['risk_profile_index'], term]
-    if effective_equity < car['sales_price'] * required_dp_pct:
+    required_dp_pct = DOWN_PAYMENT_TABLE.loc[customer["risk_profile_index"], term]
+    if effective_equity < car["sales_price"] * required_dp_pct:
         return None
 
     # 6. Determine interest rate with term premium
@@ -328,7 +473,7 @@ def _generate_single_offer(customer, car, term, interest_rate, fees_config, paym
         final_rate += 0.015
 
     # 7. Manual monthly payment calculation
-    gps_monthly_fee = fees_config.get('fixed_fee', 0) * IVA_RATE
+    gps_monthly_fee = fees_config.get("fixed_fee", 0) * IVA_RATE
     actual_monthly_payment = _calculate_manual_payment(
         loan_amount_needed,
         final_rate,
@@ -340,65 +485,68 @@ def _generate_single_offer(customer, car, term, interest_rate, fees_config, paym
     )
 
     # 8. Validate payment delta
-    payment_delta = (actual_monthly_payment / customer['current_monthly_payment']) - 1
+    payment_delta = (actual_monthly_payment / customer["current_monthly_payment"]) - 1
     valid_tier = False
     for tier, (min_d, max_d) in payment_delta_tiers.items():
         if min_d <= payment_delta <= max_d:
             valid_tier = True
             break
-    
+
     if not valid_tier:
         return None  # Payment delta is outside acceptable ranges
-    
+
     # SUCCESS! Build the final offer dictionary
     offer_data = {
-        'car_id': car['car_id'],
-        'car_model': car['model'],
-        'new_car_price': car['sales_price'],
-        'term': term,
-        'monthly_payment': actual_monthly_payment,
-        'payment_delta': payment_delta,
-        'loan_amount': loan_amount_needed,
-        'effective_equity': effective_equity,
-        'cxa_amount': cxa_amount,
-        'service_fee_amount': service_fee_amt,
-        'kavak_total_amount': kavak_total_amt,
-        'insurance_amount': insurance_amt,
-        'npv': calculate_final_npv(loan_amount_needed, final_rate, term),
-        'fees_applied': fees_config,
-        'interest_rate': final_rate
+        "car_id": car["car_id"],
+        "car_model": car["model"],
+        "new_car_price": car["sales_price"],
+        "term": term,
+        "monthly_payment": actual_monthly_payment,
+        "payment_delta": payment_delta,
+        "loan_amount": loan_amount_needed,
+        "effective_equity": effective_equity,
+        "cxa_amount": cxa_amount,
+        "service_fee_amount": service_fee_amt,
+        "kavak_total_amount": kavak_total_amt,
+        "insurance_amount": insurance_amt,
+        "npv": calculate_final_npv(loan_amount_needed, final_rate, term),
+        "fees_applied": fees_config,
+        "interest_rate": final_rate,
     }
     return offer_data
 
-def _calculate_forward_payment(loan_amount, interest_rate, term, fees_config, car_price):
+
+def _calculate_forward_payment(
+    loan_amount, interest_rate, term, fees_config, car_price
+):
     """
     A precise forward payment calculator that matches the solver's logic.
     """
     tasa_mensual_sin_iva = interest_rate / 12
     tasa_mensual_con_iva = tasa_mensual_sin_iva * IVA_RATE
-    
+
     # Calculate financed amounts
-    valor_kt = fees_config.get('kavak_total_amount', 0)
-    valor_seguro = fees_config.get('insurance_amount', 0)
-    valor_service_fee = car_price * fees_config.get('service_fee_pct', 0)
-    
+    valor_kt = fees_config.get("kavak_total_amount", 0)
+    valor_seguro = fees_config.get("insurance_amount", 0)
+    valor_service_fee = car_price * fees_config.get("service_fee_pct", 0)
+
     # We sum up the individual PMT of each financed component
     total_payment = npf.pmt(tasa_mensual_con_iva, term, -loan_amount)
-    
+
     # Service fee financed over the full loan term
     if valor_service_fee > 0:
         total_payment += npf.pmt(tasa_mensual_con_iva, term, -valor_service_fee)
-    
+
     # Kavak Total financed over the full loan term
     if valor_kt > 0:
         total_payment += npf.pmt(tasa_mensual_con_iva, term, -valor_kt)
-    
+
     # Insurance financed over 12 months
     if valor_seguro > 0:
         total_payment += npf.pmt(tasa_mensual_con_iva, 12, -valor_seguro)
-        
+
     # Fixed fee (GPS) with IVA, spread over term
-    total_payment += (fees_config.get('fixed_fee', 0) * IVA_RATE) / term
+    total_payment += (fees_config.get("fixed_fee", 0) * IVA_RATE) / term
 
     return total_payment
 
@@ -416,25 +564,37 @@ def _calculate_manual_payment(
     monthly_rate_interest = interest_rate / 12
     monthly_rate_principal = (interest_rate * IVA_RATE) / 12
 
-    financed_main = loan_amount + service_fee_amt + kavak_total_amt
-
-    principal_main = abs(
-        npf.ppmt(monthly_rate_principal, 1, term, -financed_main)
+    # Component 1: Main loan amount
+    principal_main = abs(npf.ppmt(monthly_rate_principal, 1, term, -loan_amount))
+    interest_main = (
+        abs(npf.ipmt(monthly_rate_interest, 1, term, -loan_amount)) * IVA_RATE
     )
-    interest_main = abs(
-        npf.ipmt(monthly_rate_interest, 1, term, -financed_main)
-    ) * IVA_RATE
 
-    principal_ins = abs(
-        npf.ppmt(monthly_rate_principal, 1, 12, -insurance_amt)
+    # Component 2: Financed service fee
+    principal_sf = abs(npf.ppmt(monthly_rate_principal, 1, term, -service_fee_amt))
+    interest_sf = (
+        abs(npf.ipmt(monthly_rate_interest, 1, term, -service_fee_amt)) * IVA_RATE
     )
-    interest_ins = abs(
-        npf.ipmt(monthly_rate_interest, 1, 12, -insurance_amt)
-    ) * IVA_RATE
+
+    # Component 3: Financed Kavak Total
+    principal_kt = abs(npf.ppmt(monthly_rate_principal, 1, term, -kavak_total_amt))
+    interest_kt = (
+        abs(npf.ipmt(monthly_rate_interest, 1, term, -kavak_total_amt)) * IVA_RATE
+    )
+
+    # Component 4: Insurance financed over 12 months
+    principal_ins = abs(npf.ppmt(monthly_rate_principal, 1, 12, -insurance_amt))
+    interest_ins = (
+        abs(npf.ipmt(monthly_rate_interest, 1, 12, -insurance_amt)) * IVA_RATE
+    )
 
     total_payment = (
         principal_main
         + interest_main
+        + principal_sf
+        + interest_sf
+        + principal_kt
+        + interest_kt
         + principal_ins
         + interest_ins
         + gps_monthly_fee
@@ -442,22 +602,37 @@ def _calculate_manual_payment(
 
     return total_payment
 
+
 def _generate_range(start, end, step):
     """Generate a range of values with specified step size, handling floating point precision."""
     import numpy as np
+
     return np.arange(start, end + step, step)
 
-def _run_search_phase_with_npv_filter(customer, inventory, interest_rate, fees_config, min_npv_threshold, payment_delta_tiers):
+
+def _run_search_phase_with_npv_filter(
+    customer,
+    inventory,
+    interest_rate,
+    fees_config,
+    min_npv_threshold,
+    payment_delta_tiers,
+):
     """Helper function to run search with NPV filtering applied."""
     found_offers = []
     for car_index, car in inventory.iterrows():
         for term in TERM_SEARCH_ORDER:
-            offer = _generate_single_offer(customer, car, term, interest_rate, fees_config, payment_delta_tiers)
-            if offer and offer['npv'] >= min_npv_threshold:  # Apply NPV filter
+            offer = _generate_single_offer(
+                customer, car, term, interest_rate, fees_config, payment_delta_tiers
+            )
+            if offer and offer["npv"] >= min_npv_threshold:  # Apply NPV filter
                 found_offers.append(offer)
     return found_offers
 
-def _finalize_optimized_offers_dataframe(offers_list, current_monthly_payment, engine_config, payment_delta_tiers):
+
+def _finalize_optimized_offers_dataframe(
+    offers_list, current_monthly_payment, engine_config, payment_delta_tiers
+):
     """
     Advanced finalization for range optimization with NPV-based ranking within tiers.
     """
@@ -465,50 +640,59 @@ def _finalize_optimized_offers_dataframe(offers_list, current_monthly_payment, e
         return pd.DataFrame()
 
     df = pd.DataFrame(offers_list)
-    df['payment_delta'] = (df['monthly_payment'] / current_monthly_payment) - 1
+    df["payment_delta"] = (df["monthly_payment"] / current_monthly_payment) - 1
 
     def assign_tier(delta):
         for tier, (min_d, max_d) in payment_delta_tiers.items():
             if min_d <= delta <= max_d:
                 return tier
-        return 'N/A'
-        
-    df['tier'] = df['payment_delta'].apply(assign_tier)
+        return "N/A"
+
+    df["tier"] = df["payment_delta"].apply(assign_tier)
     # Filter out any offers that might have fallen out of bounds after precise calculation
-    df = df[df['tier'] != 'N/A']
-    
+    df = df[df["tier"] != "N/A"]
+
     # Remove duplicates: keep the offer with highest NPV for each car/term combination
-    df = df.sort_values('npv', ascending=False).drop_duplicates(subset=['car_id', 'term'], keep='first')
-    
+    df = df.sort_values("npv", ascending=False).drop_duplicates(
+        subset=["car_id", "term"], keep="first"
+    )
+
     # Rank offers within each tier by NPV (descending)
-    df['npv_rank_within_tier'] = df.groupby('tier')['npv'].rank(method='dense', ascending=False)
-    
+    df["npv_rank_within_tier"] = df.groupby("tier")["npv"].rank(
+        method="dense", ascending=False
+    )
+
     # Limit offers per tier if specified
-    max_offers_per_tier = engine_config.get('max_offers_per_tier', 50)  # Default: top 50 per tier
-    df = df.groupby('tier').head(max_offers_per_tier).reset_index(drop=True)
-    
+    max_offers_per_tier = engine_config.get(
+        "max_offers_per_tier", 50
+    )  # Default: top 50 per tier
+    df = df.groupby("tier").head(max_offers_per_tier).reset_index(drop=True)
+
     # Sort by tier preference (Refresh > Upgrade > Max Upgrade) then by NPV within tier
-    tier_order = {'Refresh': 1, 'Upgrade': 2, 'Max Upgrade': 3}
-    df['tier_priority'] = df['tier'].map(tier_order)
-    df = df.sort_values(['tier_priority', 'npv'], ascending=[True, False])
-    
+    tier_order = {"Refresh": 1, "Upgrade": 2, "Max Upgrade": 3}
+    df["tier_priority"] = df["tier"].map(tier_order)
+    df = df.sort_values(["tier_priority", "npv"], ascending=[True, False])
+
     return df
 
-def _finalize_offers_dataframe(offers_list, current_monthly_payment, payment_delta_tiers):
+
+def _finalize_offers_dataframe(
+    offers_list, current_monthly_payment, payment_delta_tiers
+):
     """Helper to convert list of offer dicts to a final DataFrame with tiers."""
     if not offers_list:
         return pd.DataFrame()
 
     df = pd.DataFrame(offers_list)
-    df['payment_delta'] = (df['monthly_payment'] / current_monthly_payment) - 1
+    df["payment_delta"] = (df["monthly_payment"] / current_monthly_payment) - 1
 
     def assign_tier(delta):
         for tier, (min_d, max_d) in payment_delta_tiers.items():
             if min_d <= delta <= max_d:
                 return tier
-        return 'N/A'
-        
-    df['tier'] = df['payment_delta'].apply(assign_tier)
+        return "N/A"
+
+    df["tier"] = df["payment_delta"].apply(assign_tier)
     # Filter out any offers that might have fallen out of bounds after precise calculation
-    df = df[df['tier'] != 'N/A']
+    df = df[df["tier"] != "N/A"]
     return df

--- a/main.py
+++ b/main.py
@@ -17,12 +17,19 @@ import time
 
 # Import core modules
 from core.engine import run_engine_for_customer
+from core.calculator import generate_amortization_table
 from core.data_loader import data_loader
-from core.config_manager import save_engine_config, load_engine_config, save_scenario_results, load_latest_scenario_results
+from core.config_manager import (
+    save_engine_config,
+    load_engine_config,
+    save_scenario_results,
+    load_latest_scenario_results,
+)
 
 # Global variables for data
 customers_df = pd.DataFrame()
 inventory_df = pd.DataFrame()
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -30,58 +37,76 @@ async def lifespan(app: FastAPI):
     global customers_df, inventory_df
     try:
         print("🚀 Loading real data from Redshift and CSV...")
-        
+
         # Try to load real data first
         customers_df, inventory_df = data_loader.load_all_data()
-        
+
         # Handle partial data loading (customer data loaded but inventory failed)
         if customers_df.empty:
             print("⚠️ Customer data loading failed, falling back to sample data...")
             try:
-                customers_df = pd.read_csv('data/sample_customer_data.csv')
+                customers_df = pd.read_csv("data/sample_customer_data.csv")
                 print("✅ Sample customer data loaded successfully.")
             except FileNotFoundError as e:
                 print(f"❌ ERROR: Could not load sample customer data: {e.filename}")
                 customers_df = pd.DataFrame()
         else:
             print("✅ Real customer data loaded successfully.")
-            
+
         if inventory_df.empty:
             print("⚠️ Inventory data loading failed, using default inventory...")
             # Create a minimal inventory for testing
-            inventory_df = pd.DataFrame({
-                'car_id': [2001, 2002, 2003, 2004, 2005],
-                'model': ['Honda Civic 2024', 'Volkswagen Jetta 2024', 'Hyundai Elantra 2022', 'Kia Optima 2024', 'Ford Focus 2024'],
-                'sales_price': [290596.69, 291786.61, 430401.55, 402160.23, 282354.12]
-            })
+            inventory_df = pd.DataFrame(
+                {
+                    "car_id": [2001, 2002, 2003, 2004, 2005],
+                    "model": [
+                        "Honda Civic 2024",
+                        "Volkswagen Jetta 2024",
+                        "Hyundai Elantra 2022",
+                        "Kia Optima 2024",
+                        "Ford Focus 2024",
+                    ],
+                    "sales_price": [
+                        290596.69,
+                        291786.61,
+                        430401.55,
+                        402160.23,
+                        282354.12,
+                    ],
+                }
+            )
             print("✅ Default inventory data created.")
-        
-        print(f"📊 Final loaded data: {len(customers_df)} customers and {len(inventory_df)} cars")
-        
+
+        print(
+            f"📊 Final loaded data: {len(customers_df)} customers and {len(inventory_df)} cars"
+        )
+
     except Exception as e:
         print(f"❌ CRITICAL ERROR during data loading: {str(e)}")
         # Try sample data as last resort
         try:
-            customers_df = pd.read_csv('data/sample_customer_data.csv')
-            inventory_df = pd.read_csv('data/sample_inventory_data.csv')
+            customers_df = pd.read_csv("data/sample_customer_data.csv")
+            inventory_df = pd.read_csv("data/sample_inventory_data.csv")
             print("✅ Fallback to sample data successful.")
         except:
             customers_df = pd.DataFrame()
             inventory_df = pd.DataFrame()
             print("❌ All data loading methods failed.")
-            
+
     yield
+
 
 # --- App Initialization ---
 app = FastAPI(
     title="Kavak Trade-Up Engine",
     description="API and Web Dashboard for generating vehicle upgrade offers.",
-    lifespan=lifespan
+    lifespan=lifespan,
 )
 
 # --- Mount Static Files & Templates ---
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 templates = Jinja2Templates(directory="app/templates")
+
 
 # --- Pydantic Models for API ---
 class CustomerData(BaseModel):
@@ -92,33 +117,37 @@ class CustomerData(BaseModel):
     risk_profile_name: str
     risk_profile_index: int = Field(..., ge=0)
 
+
 class CarData(BaseModel):
     car_id: int
     model: str
     sales_price: float = Field(..., gt=0)
 
+
 class EngineConfig(BaseModel):
     include_kavak_total: bool = True
     use_custom_params: bool = False
+
 
 class PaymentDeltaTiers(BaseModel):
     refresh: List[float]
     upgrade: List[float]
     max_upgrade: List[float]
 
+
 class ScenarioConfig(BaseModel):
     # Engine Mode
     use_custom_params: bool = False
     use_range_optimization: bool = False
     include_kavak_total: bool = True
-    
+
     # Fee Structure (only used if use_custom_params = True)
     service_fee_pct: float = 0.05
     cxa_pct: float = 0.04
     cac_bonus: float = 5000.0
     insurance_amount: float = 10999.0
     gps_fee: float = 350.0
-    
+
     # Range Optimization (only used if use_range_optimization = True)
     service_fee_range: List[float] = [0.0, 5.0]
     cxa_range: List[float] = [0.0, 4.0]
@@ -127,126 +156,142 @@ class ScenarioConfig(BaseModel):
     cxa_step: float = 0.01  # 1 basis point
     cac_bonus_step: float = 100  # 100 MXN steps
     max_offers_per_tier: int = 50
-    
+
     # Payment Delta Thresholds
     payment_delta_tiers: PaymentDeltaTiers = PaymentDeltaTiers(
-        refresh=[-0.05, 0.05],
-        upgrade=[0.0501, 0.25],
-        max_upgrade=[0.2501, 1.00]
+        refresh=[-0.05, 0.05], upgrade=[0.0501, 0.25], max_upgrade=[0.2501, 1.00]
     )
-    
+
     # Engine Behavior
     term_priority: str = "standard"
     min_npv_threshold: float = 5000.0
+
 
 class OfferRequest(BaseModel):
     customer_data: CustomerData
     inventory: List[CarData]
     engine_config: EngineConfig
 
+
 # --- Helper Functions ---
 def calculate_real_metrics():
     """Calculate REAL portfolio metrics from your actual customer data."""
     if customers_df.empty:
         return {
-            'total_customers': 0, 
-            'total_offers': 0, 
-            'avg_npv': 0, 
-            'avg_offers_per_customer': 0, 
-            'tier_distribution': {}, 
-            'top_cars': [],
-            'risk_profile_distribution': {}
+            "total_customers": 0,
+            "total_offers": 0,
+            "avg_npv": 0,
+            "avg_offers_per_customer": 0,
+            "tier_distribution": {},
+            "top_cars": [],
+            "risk_profile_distribution": {},
         }
-    
+
     # REAL CUSTOMER DATA ANALYSIS
     total_customers = len(customers_df)
-    
+
     # Analyze actual risk profiles from your data
-    risk_profile_counts = customers_df['risk_profile_name'].value_counts().to_dict()
-    
+    risk_profile_counts = customers_df["risk_profile_name"].value_counts().to_dict()
+
     # Calculate real averages from your customer data
-    avg_monthly_payment = customers_df['current_monthly_payment'].mean()
-    avg_vehicle_equity = customers_df['vehicle_equity'].mean()
-    avg_car_price = customers_df['current_car_price'].mean()
-    
+    avg_monthly_payment = customers_df["current_monthly_payment"].mean()
+    avg_vehicle_equity = customers_df["vehicle_equity"].mean()
+    avg_car_price = customers_df["current_car_price"].mean()
+
     # Estimate offers based on risk profiles and financial data
     # Higher risk profiles and higher payments = more offers available
-    risk_multipliers = {'A1': 12, 'A2': 10, 'B': 8, 'C1': 6, 'C2': 4, 'other': 5}
+    risk_multipliers = {"A1": 12, "A2": 10, "B": 8, "C1": 6, "C2": 4, "other": 5}
     total_estimated_offers = 0
-    
+
     for risk_profile, count in risk_profile_counts.items():
-        multiplier = risk_multipliers.get(risk_profile, risk_multipliers['other'])
+        multiplier = risk_multipliers.get(risk_profile, risk_multipliers["other"])
         total_estimated_offers += count * multiplier
-    
-    avg_offers_per_customer = total_estimated_offers / total_customers if total_customers > 0 else 0
-    
+
+    avg_offers_per_customer = (
+        total_estimated_offers / total_customers if total_customers > 0 else 0
+    )
+
     # Estimate NPV based on equity and payment data
     # Higher equity and payments typically mean higher NPV potential
     estimated_avg_npv = int((avg_vehicle_equity * 0.08) + (avg_monthly_payment * 2.5))
-    
+
     # Real inventory analysis
     top_cars_data = []
     if not inventory_df.empty:
         # Select most attractive cars (varied price points)
-        inventory_sample = inventory_df.sample(min(10, len(inventory_df)), random_state=42)
+        inventory_sample = inventory_df.sample(
+            min(10, len(inventory_df)), random_state=42
+        )
         top_cars_data = [
             {
-                'Model': row['model'], 
-                'Price': f"${row['sales_price']:,.0f}",
-                'Estimated_Matches': int(total_customers * 0.15)  # Estimate 15% customer match rate
-            } 
+                "Model": row["model"],
+                "Price": f"${row['sales_price']:,.0f}",
+                "Estimated_Matches": int(
+                    total_customers * 0.15
+                ),  # Estimate 15% customer match rate
+            }
             for _, row in inventory_sample.iterrows()
         ]
-    
+
     # Tier distribution based on typical patterns
     return {
-        'total_customers': total_customers,
-        'total_offers': int(total_estimated_offers),
-        'avg_npv': estimated_avg_npv,
-        'avg_offers_per_customer': round(avg_offers_per_customer, 1),
-        'avg_monthly_payment': f"${avg_monthly_payment:,.0f}",
-        'avg_vehicle_equity': f"${avg_vehicle_equity:,.0f}",
-        'avg_car_price': f"${avg_car_price:,.0f}",
-        'tier_distribution': {
-            'Refresh': int(total_estimated_offers * 0.35),
-            'Upgrade': int(total_estimated_offers * 0.50),
-            'Max Upgrade': int(total_estimated_offers * 0.15)
+        "total_customers": total_customers,
+        "total_offers": int(total_estimated_offers),
+        "avg_npv": estimated_avg_npv,
+        "avg_offers_per_customer": round(avg_offers_per_customer, 1),
+        "avg_monthly_payment": f"${avg_monthly_payment:,.0f}",
+        "avg_vehicle_equity": f"${avg_vehicle_equity:,.0f}",
+        "avg_car_price": f"${avg_car_price:,.0f}",
+        "tier_distribution": {
+            "Refresh": int(total_estimated_offers * 0.35),
+            "Upgrade": int(total_estimated_offers * 0.50),
+            "Max Upgrade": int(total_estimated_offers * 0.15),
         },
-        'risk_profile_distribution': risk_profile_counts,
-        'top_cars': top_cars_data
+        "risk_profile_distribution": risk_profile_counts,
+        "top_cars": top_cars_data,
     }
+
 
 # --- HTML Endpoints ---
 @app.get("/", response_class=HTMLResponse)
 async def serve_main_dashboard(request: Request):
     """Serves the main portfolio dashboard."""
     metrics = calculate_real_metrics()
-    return templates.TemplateResponse("main_dashboard.html", {"request": request, "metrics": metrics})
+    return templates.TemplateResponse(
+        "main_dashboard.html", {"request": request, "metrics": metrics}
+    )
+
 
 @app.get("/customer/{customer_id}", response_class=HTMLResponse)
 async def serve_customer_dashboard(request: Request, customer_id: str):
     """Serves the deep-dive dashboard for a single customer."""
-    customer_data = customers_df[customers_df['customer_id'] == customer_id]
+    customer_data = customers_df[customers_df["customer_id"] == customer_id]
     if customer_data.empty:
         raise HTTPException(status_code=404, detail="Customer not found")
-    
+
     customer_dict = customer_data.iloc[0].to_dict()
-    return templates.TemplateResponse("customer_view.html", {"request": request, "customer": customer_dict})
+    return templates.TemplateResponse(
+        "customer_view.html", {"request": request, "customer": customer_dict}
+    )
+
 
 @app.get("/config", response_class=HTMLResponse)
 async def serve_config_page(request: Request):
     """Serves the global configuration page."""
     return templates.TemplateResponse("global_config.html", {"request": request})
 
+
 @app.get("/calculations", response_class=HTMLResponse)
 async def serve_calculations_page(request: Request):
     """Serves the calculations explanation page in Spanish."""
     return templates.TemplateResponse("calculations.html", {"request": request})
 
+
 @app.get("/customers", response_class=HTMLResponse)
 async def serve_customers_page(request: Request):
     """Serves the customer list page."""
     return templates.TemplateResponse("customer_list.html", {"request": request})
+
 
 # --- API Endpoints ---
 @app.post("/api/generate-offers", tags=["Offers"])
@@ -255,7 +300,7 @@ def generate_offers(request: OfferRequest) -> Dict:
     try:
         inventory_df_request = pd.DataFrame([car.dict() for car in request.inventory])
         customer_dict = request.customer_data.dict()
-        
+
         # Load saved configuration and merge with request config
         saved_config = load_engine_config()
         config_dict = {**saved_config, **request.engine_config.dict()}
@@ -263,37 +308,56 @@ def generate_offers(request: OfferRequest) -> Dict:
         if inventory_df_request.empty:
             raise HTTPException(status_code=400, detail="Inventory cannot be empty.")
 
-        all_offers_df = run_engine_for_customer(customer_dict, inventory_df_request, config_dict)
+        all_offers_df = run_engine_for_customer(
+            customer_dict, inventory_df_request, config_dict
+        )
 
         if all_offers_df.empty:
             return {"message": "No valid offers found for this customer.", "offers": {}}
 
         offers_by_tier = {
-            tier: group.to_dict(orient='records')
-            for tier, group in all_offers_df.groupby('tier')
+            tier: group.to_dict(orient="records")
+            for tier, group in all_offers_df.groupby("tier")
         }
-        
+
         return {
             "message": f"Successfully generated {len(all_offers_df)} offers.",
-            "offers": offers_by_tier
+            "offers": offers_by_tier,
         }
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"An internal error occurred: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"An internal error occurred: {str(e)}"
+        )
+
+
+@app.post("/api/amortization-table", tags=["Offers"])
+def amortization_table(offer: Dict):
+    """Return full amortization table for a given offer."""
+    try:
+        table = generate_amortization_table(offer)
+        return {"table": table}
+    except Exception as e:
+        raise HTTPException(
+            status_code=500, detail=f"Failed to generate amortization table: {str(e)}"
+        )
+
 
 @app.get("/api/customers", tags=["Customers"])
 def get_all_customers():
     """Returns a list of all customers."""
     if customers_df.empty:
         return []
-    return customers_df.to_dict('records')
+    return customers_df.to_dict("records")
+
 
 @app.get("/api/inventory", tags=["Inventory"])
 def get_inventory():
     """Returns the full inventory list."""
     if inventory_df.empty:
         return []
-    return inventory_df.to_dict('records')
+    return inventory_df.to_dict("records")
+
 
 @app.get("/api/config-status", tags=["Configuration"])
 def get_config_status():
@@ -301,21 +365,30 @@ def get_config_status():
     try:
         config = load_engine_config()
         latest_results = load_latest_scenario_results()
-        
+
         return {
-            "has_custom_config": config.get('use_custom_params', False) or config.get('use_range_optimization', False),
-            "mode": "Range Optimization" if config.get('use_range_optimization') else 
-                    ("Custom Parameters" if config.get('use_custom_params') else "Default Hierarchical"),
-            "last_updated": config.get('last_updated', 'Never'),
-            "latest_results": latest_results
+            "has_custom_config": config.get("use_custom_params", False)
+            or config.get("use_range_optimization", False),
+            "mode": (
+                "Range Optimization"
+                if config.get("use_range_optimization")
+                else (
+                    "Custom Parameters"
+                    if config.get("use_custom_params")
+                    else "Default Hierarchical"
+                )
+            ),
+            "last_updated": config.get("last_updated", "Never"),
+            "latest_results": latest_results,
         }
     except Exception as e:
         return {
             "has_custom_config": False,
             "mode": "Default Hierarchical",
             "last_updated": "Never",
-            "latest_results": None
+            "latest_results": None,
         }
+
 
 @app.post("/api/save-config", tags=["Configuration"])
 def save_configuration(config: ScenarioConfig):
@@ -323,40 +396,46 @@ def save_configuration(config: ScenarioConfig):
     try:
         config_dict = config.dict()
         if save_engine_config(config_dict):
-            return {"message": "Configuration saved successfully", "config": config_dict}
+            return {
+                "message": "Configuration saved successfully",
+                "config": config_dict,
+            }
         else:
             raise HTTPException(status_code=500, detail="Failed to save configuration")
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error saving configuration: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Error saving configuration: {str(e)}"
+        )
+
 
 @app.post("/api/scenario-analysis", tags=["Configuration"])
 def run_scenario_analysis(config: ScenarioConfig):
     """Run a REAL scenario analysis by actually executing the engine with given configuration."""
     try:
         start_time = time.time()
-        
+
         # Save configuration first
         config_dict = config.dict()
         save_engine_config(config_dict)
-        
+
         # Initialize metrics
         total_customers = len(customers_df) if not customers_df.empty else 0
         total_offers = 0
         total_npv = 0
-        offers_by_tier = {'Refresh': 0, 'Upgrade': 0, 'Max Upgrade': 0}
+        offers_by_tier = {"Refresh": 0, "Upgrade": 0, "Max Upgrade": 0}
         processing_errors = 0
-        
+
         # Get baseline metrics for comparison (default configuration)
         baseline_config = {
-            'use_custom_params': False,
-            'use_range_optimization': False,
-            'include_kavak_total': True,
-            'min_npv_threshold': 5000.0
+            "use_custom_params": False,
+            "use_range_optimization": False,
+            "include_kavak_total": True,
+            "min_npv_threshold": 5000.0,
         }
-        
+
         print(f"🎯 Starting REAL scenario analysis with {total_customers} customers...")
         print(f"Configuration: {config_dict}")
-        
+
         # Sample customers for analysis (process a subset for performance)
         sample_size = min(100, total_customers)  # Process up to 100 customers
         if total_customers > sample_size:
@@ -364,38 +443,46 @@ def run_scenario_analysis(config: ScenarioConfig):
             print(f"📊 Processing sample of {sample_size} customers for analysis...")
         else:
             customer_sample = customers_df
-        
+
         # Run engine for each customer in sample
         for _, customer in customer_sample.iterrows():
             try:
                 customer_dict = customer.to_dict()
-                
+
                 # Run with scenario configuration
-                offers_df = run_engine_for_customer(customer_dict, inventory_df, config_dict)
-                
+                offers_df = run_engine_for_customer(
+                    customer_dict, inventory_df, config_dict
+                )
+
                 if not offers_df.empty:
                     total_offers += len(offers_df)
-                    total_npv += offers_df['npv'].sum()
-                    
+                    total_npv += offers_df["npv"].sum()
+
                     # Count by tier
-                    for tier in offers_df['tier'].unique():
-                        offers_by_tier[tier] += len(offers_df[offers_df['tier'] == tier])
-                        
+                    for tier in offers_df["tier"].unique():
+                        offers_by_tier[tier] += len(
+                            offers_df[offers_df["tier"] == tier]
+                        )
+
             except Exception as e:
-                print(f"⚠️ Error processing customer {customer.get('customer_id', 'unknown')}: {e}")
+                print(
+                    f"⚠️ Error processing customer {customer.get('customer_id', 'unknown')}: {e}"
+                )
                 processing_errors += 1
-        
+
         # Calculate averages
         processed_customers = sample_size - processing_errors
-        avg_offers_per_customer = total_offers / processed_customers if processed_customers > 0 else 0
+        avg_offers_per_customer = (
+            total_offers / processed_customers if processed_customers > 0 else 0
+        )
         avg_npv_per_offer = total_npv / total_offers if total_offers > 0 else 0
-        
+
         # Extrapolate to full portfolio
         extrapolated_total_offers = int(avg_offers_per_customer * total_customers)
         extrapolated_total_npv = int(avg_npv_per_offer * extrapolated_total_offers)
-        
+
         execution_time = time.time() - start_time
-        
+
         # Build results
         results = {
             "scenario_config": config_dict,
@@ -404,39 +491,76 @@ def run_scenario_analysis(config: ScenarioConfig):
                 "total_customers": total_customers,
                 "processed_customers": processed_customers,
                 "processing_errors": processing_errors,
-                "execution_time_seconds": round(execution_time, 2)
+                "execution_time_seconds": round(execution_time, 2),
             },
             "actual_metrics": {
                 "total_offers": extrapolated_total_offers,
                 "average_npv_per_offer": int(avg_npv_per_offer),
                 "total_portfolio_npv": extrapolated_total_npv,
                 "offers_per_customer": round(avg_offers_per_customer, 1),
-                "tier_distribution": offers_by_tier
+                "tier_distribution": offers_by_tier,
             },
             "mode_info": {
-                "mode": "Range Optimization" if config_dict.get('use_range_optimization') else 
-                        ("Custom Parameters" if config_dict.get('use_custom_params') else "Default Hierarchical"),
-                "parameter_combinations": 0
-            }
+                "mode": (
+                    "Range Optimization"
+                    if config_dict.get("use_range_optimization")
+                    else (
+                        "Custom Parameters"
+                        if config_dict.get("use_custom_params")
+                        else "Default Hierarchical"
+                    )
+                ),
+                "parameter_combinations": 0,
+            },
         }
-        
+
         # Calculate parameter combinations for range optimization
-        if config_dict.get('use_range_optimization'):
-            service_fee_count = int((config_dict['service_fee_range'][1] - config_dict['service_fee_range'][0]) / config_dict['service_fee_step']) + 1
-            cxa_count = int((config_dict['cxa_range'][1] - config_dict['cxa_range'][0]) / config_dict['cxa_step']) + 1
-            cac_count = int((config_dict['cac_bonus_range'][1] - config_dict['cac_bonus_range'][0]) / config_dict['cac_bonus_step']) + 1
-            results['mode_info']['parameter_combinations'] = service_fee_count * cxa_count * cac_count
-        
+        if config_dict.get("use_range_optimization"):
+            service_fee_count = (
+                int(
+                    (
+                        config_dict["service_fee_range"][1]
+                        - config_dict["service_fee_range"][0]
+                    )
+                    / config_dict["service_fee_step"]
+                )
+                + 1
+            )
+            cxa_count = (
+                int(
+                    (config_dict["cxa_range"][1] - config_dict["cxa_range"][0])
+                    / config_dict["cxa_step"]
+                )
+                + 1
+            )
+            cac_count = (
+                int(
+                    (
+                        config_dict["cac_bonus_range"][1]
+                        - config_dict["cac_bonus_range"][0]
+                    )
+                    / config_dict["cac_bonus_step"]
+                )
+                + 1
+            )
+            results["mode_info"]["parameter_combinations"] = (
+                service_fee_count * cxa_count * cac_count
+            )
+
         # Save results
         save_scenario_results(results)
-        
+
         return results
-        
+
     except Exception as e:
         print(f"❌ Scenario analysis failed: {str(e)}")
         import traceback
+
         traceback.print_exc()
-        raise HTTPException(status_code=500, detail=f"Scenario analysis failed: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Scenario analysis failed: {str(e)}"
+        )
+
 
 if __name__ == "__main__":
     print("🚗 Starting Kavak Trade-Up Engine Dashboard...")


### PR DESCRIPTION
## Summary
- implement sequential default hierarchical search logic
- correct manual payment calculation to include all components
- add amortization table generation
- expose new API endpoint for amortization tables
- add frontend button and modal to view amortization schedule

## Testing
- `pytest -q` *(fails: customers and inventory API tests return 500)*

------
https://chatgpt.com/codex/tasks/task_e_685476a58bb08322ac85695c9349e2ff