### PR TITLE
Fix loan calc for GPS fee

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -428,7 +428,7 @@ def _generate_single_offer(
     if car["sales_price"] <= customer["current_car_price"]:
         return None
 
-    # 2. Resolve CXA circular dependency including GPS installation fee
+    # 2. Resolve CXA circular dependency
     cxa_pct = fees_config.get("cxa_pct", 0)
     cac_bonus = fees_config.get("cac_bonus", 0)
     gps_install_with_iva = GPS_INSTALLATION_FEE * IVA_RATE
@@ -438,10 +438,7 @@ def _generate_single_offer(
         return None
 
     loan_amount_needed = (
-        car["sales_price"]
-        - customer["vehicle_equity"]
-        - cac_bonus
-        + gps_install_with_iva
+        car["sales_price"] - customer["vehicle_equity"] - cac_bonus
     ) / denominator
 
     if loan_amount_needed <= 0:
@@ -455,7 +452,7 @@ def _generate_single_offer(
         customer["risk_profile_name"], DEFAULT_FEES["insurance_amount"]
     )
 
-    # 4. Effective equity calculation
+    # 4. Effective equity calculation (GPS and CXA reduce available equity)
     effective_equity = (
         customer["vehicle_equity"] + cac_bonus - cxa_amount - gps_install_with_iva
     )

--- a/core/test_gps_financing.py
+++ b/core/test_gps_financing.py
@@ -1,0 +1,39 @@
+import pytest
+from core.engine import _generate_single_offer
+from core.config import (
+    DEFAULT_FEES,
+    PAYMENT_DELTA_TIERS,
+    IVA_RATE,
+    GPS_INSTALLATION_FEE,
+    get_hardcoded_financial_parameters,
+)
+
+INTEREST_RATE_TABLE, _ = get_hardcoded_financial_parameters()
+
+
+def test_gps_installation_not_financed():
+    customer = {
+        "current_car_price": 130000,
+        "vehicle_equity": 50000,
+        "current_monthly_payment": 9000,
+        "risk_profile_name": "A",
+        "risk_profile_index": 2,
+    }
+    car = {"car_id": "CAR1", "model": "Test", "sales_price": 200000}
+    fees = DEFAULT_FEES.copy()
+    term = 36
+    interest_rate = INTEREST_RATE_TABLE["A"]
+
+    offer = _generate_single_offer(
+        customer, car, term, interest_rate, fees, PAYMENT_DELTA_TIERS
+    )
+    assert offer is not None
+
+    gps_install_with_iva = GPS_INSTALLATION_FEE * IVA_RATE
+    expected_loan = (
+        car["sales_price"] - customer["vehicle_equity"] - fees["cac_bonus"]
+    ) / (1 - fees["cxa_pct"])
+    assert offer["loan_amount"] == pytest.approx(expected_loan)
+    assert offer["loan_amount"] + offer["effective_equity"] == pytest.approx(
+        car["sales_price"] - gps_install_with_iva
+    )


### PR DESCRIPTION
## Summary
- exclude GPS install fee from financed amount in loan calculation
- deduct CXA and GPS from effective equity
- test that GPS install fee does not increase loan amount

## Testing
- `pytest core/test_gps_financing.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559a9ef7608322bd5425a12b73d34c