### PR TITLE
Fix amortization modal

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -721,6 +721,7 @@ body {
 
 /* Amortization modal */
 .modal {
+    display: none;
     position: fixed;
     z-index: 1000;
     left: 0;

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -8,7 +8,8 @@
 let currentCustomer = null;
 let allCustomers = [];
 
-document.addEventListener('DOMContentLoaded', function() {
+
+function initDashboard() {
     console.log("🚗 Kavak Dashboard JS Loaded");
     loadCustomersList();
 
@@ -27,7 +28,13 @@ document.addEventListener('DOMContentLoaded', function() {
         document.getElementById('amortization-close').addEventListener('click', closeAmortizationModal);
         window.addEventListener('click', function(evt) { if (evt.target === modal) closeAmortizationModal(); });
     }
-});
+}
+
+if (document.readyState !== 'loading') {
+    initDashboard();
+} else {
+    document.addEventListener('DOMContentLoaded', initDashboard);
+}
 
 // Initialize customer view page
 function initializeCustomerView(customerId) {


### PR DESCRIPTION
## Summary
- keep amortization modal hidden by default
- initialize dashboard JS when DOM already loaded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559ae56f6c832284ccced9a7993a50