### PR TITLE
Introduce strategy pattern for offer generation

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -8,8 +8,8 @@ from .calculator import calculate_final_npv
 # Attempt to import heavy Redshift-connected loader; gracefully skip if dependencies missing
 try:
     from .data_loader import data_loader
-except ModuleNotFoundError as e:
-    # Common in local/mock environments where redshift_connector isn't installed or supported
+except (ModuleNotFoundError, ImportError):
+    # Gracefully handle missing optional dependencies or circular imports
     data_loader = None
 from .config import *
 


### PR DESCRIPTION
## Summary
- add `SearchStrategy` abstract class and strategy implementations
- delegate offer generation to strategies in `TradeUpEngine`
- simplify `run_engine_for_customer` with new strategies
- handle optional `data_loader` import failures gracefully
- adjust loan calculation logic

## Testing
- `pytest core/test_gps_financing.py::test_gps_installation_not_financed -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559f7e0bec8322baced42de3cf4f85