### PR TITLE
Centralize engine config with Pydantic model

### DIFF
--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from core.engine import TradeUpEngine
 from core.data_loader_dev import dev_data_loader
 from core.config_manager import ConfigManager
+from core.settings import EngineSettings
 
 # Initialize router
 router = APIRouter()
@@ -117,8 +118,8 @@ async def generate_offers(request: OfferRequest) -> Dict:
         customer_dict = request.customer_data.dict()
         
         # Load current config and merge with request config
-        config = config_manager.load_config()
-        config_dict = {**config, **request.engine_config.dict()}
+        settings: EngineSettings = config_manager.load_config()
+        config_dict = {**settings.model_dump(), **request.engine_config.dict()}
         
         # Update engine with current config
         engine.update_config(config_dict)
@@ -183,7 +184,8 @@ async def amortization_table(offer: Dict):
 async def get_config():
     """Get current engine configuration"""
     try:
-        return {"config": config_manager.load_config()}
+        settings: EngineSettings = config_manager.load_config()
+        return {"config": settings.model_dump()}
     except Exception as e:
         logging.error(f"Error loading config: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -192,7 +194,8 @@ async def get_config():
 async def get_config_status():
     """Returns the current engine configuration status"""
     try:
-        config = config_manager.load_config()
+        settings: EngineSettings = config_manager.load_config()
+        config = settings.model_dump()
         
         return {
             "has_custom_config": config.get("use_custom_params", False) or config.get("use_range_optimization", False),

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -5,63 +5,48 @@ Handles storage and retrieval of engine configuration settings
 import json
 import os
 from datetime import datetime
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Union
 import logging
 from core.logging_config import setup_logging
+from .settings import EngineSettings
 
 setup_logging(logging.INFO)
 logger = logging.getLogger(__name__)
 
 class ConfigManager:
-    def __init__(self, config_file="engine_config.json"):
+    def __init__(self, config_file: str = "engine_config.json"):
         self.config_file = config_file
-        self._default_config = {
-            'use_custom_params': False,
-            'use_range_optimization': True,
-            'include_kavak_total': True,
-            'service_fee_pct': 0.05,
-            'cxa_pct': 0.04,
-            'cac_bonus': 5000.0,
-            'insurance_amount': 10999.0,
-            'gps_fee': 350.0,
-            'service_fee_range': [0.0, 5.0],
-            'cxa_range': [0.0, 4.0],
-            'cac_bonus_range': [0.0, 10000.0],
-            'service_fee_step': 0.1,
-            'cxa_step': 0.1,
-            'cac_bonus_step': 100.0,
-            'max_offers_per_tier': 50,
-            'payment_delta_tiers': {
-                'refresh': [-0.05, 0.05],
-                'upgrade': [0.0501, 0.25],
-                'max_upgrade': [0.2501, 1.0]
-            },
-            'term_priority': 'standard',
-            'min_npv_threshold': 5000.0
-        }
+        # Default settings using the Pydantic model
+        self._default_settings = EngineSettings()
     
-    def load_config(self) -> Dict[str, Any]:
-        """Load engine configuration from file"""
+    def load_config(self) -> EngineSettings:
+        """Load engine configuration from file and validate it."""
         try:
             if os.path.exists(self.config_file):
-                with open(self.config_file, 'r') as f:
-                    config = json.load(f)
-                    logger.info(f"✅ Loaded engine configuration from {self.config_file}")
-                    return config
+                with open(self.config_file, "r") as f:
+                    data = json.load(f)
+                    logger.info(
+                        f"✅ Loaded engine configuration from {self.config_file}"
+                    )
+                    return EngineSettings.model_validate(data)
         except Exception as e:
             logger.warning(f"⚠️ Could not load config: {e}")
-        
-        # Return default configuration
-        return self._default_config.copy()
+
+        # Return default settings instance
+        return self._default_settings
     
-    def save_config(self, config: Dict[str, Any]) -> bool:
-        """Save engine configuration to file"""
+    def save_config(self, config: Union[Dict[str, Any], EngineSettings]) -> bool:
+        """Save engine configuration to file."""
         try:
-            # Add timestamp
-            config['last_updated'] = datetime.now().isoformat()
-            
-            with open(self.config_file, 'w') as f:
-                json.dump(config, f, indent=2)
+            settings = (
+                config
+                if isinstance(config, EngineSettings)
+                else EngineSettings.model_validate(config)
+            )
+            settings.last_updated = datetime.now().isoformat()
+
+            with open(self.config_file, "w") as f:
+                json.dump(settings.model_dump(), f, indent=2)
 
             logger.info(f"✅ Engine configuration saved to {self.config_file}")
             return True
@@ -70,13 +55,13 @@ class ConfigManager:
             return False
     
     def reset_config(self) -> bool:
-        """Reset configuration to defaults"""
-        return self.save_config(self._default_config.copy())
+        """Reset configuration to defaults."""
+        return self.save_config(self._default_settings)
     
     @property
-    def default_config(self) -> Dict[str, Any]:
-        """Get a copy of the default configuration"""
-        return self._default_config.copy()
+    def default_config(self) -> EngineSettings:
+        """Get the default configuration as ``EngineSettings``."""
+        return self._default_settings
 
 
 # ------------------------------------------------------------------
@@ -87,12 +72,12 @@ _manager = ConfigManager()
 SCENARIO_RESULTS_FILE = "scenario_results.json"
 
 
-def load_engine_config() -> Dict[str, Any]:
+def load_engine_config() -> EngineSettings:
     """Load the engine configuration using the shared manager."""
     return _manager.load_config()
 
 
-def save_engine_config(config: Dict[str, Any]) -> bool:
+def save_engine_config(config: Union[Dict[str, Any], EngineSettings]) -> bool:
     """Save the engine configuration via the shared manager."""
     return _manager.save_config(config)
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import List
+from pydantic import BaseModel
+
+class PaymentDeltaTiers(BaseModel):
+    refresh: List[float] = [-0.05, 0.05]
+    upgrade: List[float] = [0.0501, 0.25]
+    max_upgrade: List[float] = [0.2501, 1.0]
+
+class EngineSettings(BaseModel):
+    use_custom_params: bool = False
+    use_range_optimization: bool = True
+    include_kavak_total: bool = True
+
+    service_fee_pct: float = 0.05
+    cxa_pct: float = 0.04
+    cac_bonus: float = 5000.0
+    insurance_amount: float = 10999.0
+    gps_fee: float = 350.0
+
+    service_fee_range: List[float] = [0.0, 5.0]
+    cxa_range: List[float] = [0.0, 4.0]
+    cac_bonus_range: List[float] = [0.0, 10000.0]
+    service_fee_step: float = 0.1
+    cxa_step: float = 0.1
+    cac_bonus_step: float = 100.0
+    max_offers_per_tier: int = 50
+
+    payment_delta_tiers: PaymentDeltaTiers = PaymentDeltaTiers()
+
+    term_priority: str = "standard"
+    min_npv_threshold: float = 5000.0
+    last_updated: str | None = None


### PR DESCRIPTION
## Summary
- add `EngineSettings` Pydantic model in new `core/settings.py`
- refactor `ConfigManager` to load and save `EngineSettings`
- update FastAPI app and API routes to use the new model
- keep existing tests passing

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a94350688322ad12d909e2b1be3c