### PR TITLE
Add Redis health check integration

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,10 +12,12 @@ from pydantic import BaseModel, Field
 import pandas as pd
 from typing import List, Dict
 import uvicorn
+import os
 from contextlib import asynccontextmanager
 import time
 import logging
 from core.logging_config import setup_logging
+from core.cache_utils import redis_status
 import numpy as np
 import json
 from sse_starlette.sse import EventSourceResponse
@@ -265,6 +267,20 @@ def calculate_real_metrics():
         },
         "risk_profile_distribution": risk_profile_counts,
         "top_cars": top_cars_data,
+    }
+
+
+# --- Health Check ----------------------------------------------------
+@app.get("/health")
+async def health_check():
+    """Simple health check endpoint."""
+    return {
+        "status": "healthy",
+        "environment": os.getenv("ENVIRONMENT", "production"),
+        "external_calls": "disabled"
+        if os.getenv("DISABLE_EXTERNAL_CALLS") == "true"
+        else "enabled",
+        "redis_connected": redis_status(),
     }
 
 

--- a/main_dev.py
+++ b/main_dev.py
@@ -19,6 +19,7 @@ from fastapi.responses import HTMLResponse, JSONResponse
 import uvicorn
 import logging
 from core.logging_config import setup_logging
+from core.cache_utils import redis_status
 
 setup_logging(logging.INFO)
 logger = logging.getLogger(__name__)
@@ -76,7 +77,8 @@ async def health_check():
         "environment": "development",
         "external_calls": "disabled",
         "mock_data": "enabled",
-        "data_sources": "CSV and sample data only"
+        "data_sources": "CSV and sample data only",
+        "redis_connected": redis_status(),
     }
 
 # Include API routes


### PR DESCRIPTION
## Summary
- log Redis connection errors during cache init
- expose `redis_status()` helper
- include redis connection state in health checks
- add `/health` endpoint to production server

## Testing
- `venv/bin/python -m pytest -q -k 'not complete_system'`

------
https://chatgpt.com/codex/tasks/task_e_6855ce36b3dc8322b14cdeb9a307c38e