### PR TITLE
Add connection failure troubleshooting docs

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -146,6 +146,21 @@ The system includes built-in data validation:
 
 ### Fallback Behavior:
 If real data loading fails, the system automatically uses sample data so you can still test and develop. Check the console logs for specific error messages.
+### Common Connection Failures
+
+1. **Missing `.env` or incorrect Redshift credentials**
+   - Ensure the `.env` file is present with valid connection details.
+   - Verify `REDSHIFT_HOST`, `REDSHIFT_USER`, and `REDSHIFT_PASSWORD`.
+   - Re-run the server and check `/health` for connectivity status.
+2. **File permission issues for configuration or scenario result files**
+   - Confirm read/write access to `engine_config.json` and `scenario_results.json`.
+   - Adjust permissions using `chmod` or correct the file ownership.
+   - `/health` will report permission errors if these files are blocked.
+3. **Redis not running or unreachable**
+   - Start the Redis service locally or update the `REDIS_URL` in your `.env`.
+   - When Redis is down, the engine defaults to in-memory caching.
+   - Use `/health` to see if Redis connectivity is active.
+
 
 ## 📞 Support
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,21 @@ Then execute:
 ```bash
 pytest
 ```
+## Common Connection Failures
+
+1. **Missing `.env` or incorrect Redshift credentials**
+   - Ensure the `.env` file exists in the project root.
+   - Double-check `REDSHIFT_HOST`, `REDSHIFT_USER`, `REDSHIFT_PASSWORD`, and related values.
+   - Restart the application and visit `/health` to verify a successful connection.
+2. **File permission issues for configuration or scenario result files**
+   - Verify read/write permissions on `engine_config.json` and `scenario_results.json`.
+   - Adjust permissions with `chmod` or run the server with a user that has access.
+   - The `/health` endpoint will report errors if these files cannot be opened.
+3. **Redis not running or unreachable**
+   - Check that the Redis service is running and the `REDIS_URL` in `.env` is correct.
+   - If Redis is unavailable, the system falls back to in-memory caching.
+   - Use `/health` to confirm whether Redis connectivity is active.
+
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- document common connection issues in README
- add same troubleshooting steps in integration guide

## Testing
- `pip install pandas`
- `pip install numpy-financial`
- `pip install fastapi starlette`
- `pip install requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ce39f67083228a15daa90975e9f1