### PR TITLE
Centralize risk profile mapping

### DIFF
--- a/core/data_loader.py
+++ b/core/data_loader.py
@@ -10,6 +10,7 @@ import redshift_connector
 import logging
 from core.logging_config import setup_logging
 from core import cache_utils  # local import to avoid circular
+from core.risk_profiles import RISK_PROFILE_MAPPING
 
 # Load environment variables
 load_dotenv()
@@ -29,14 +30,8 @@ class DataLoader:
             'password': os.getenv('REDSHIFT_PASSWORD')
         }
         
-        # Risk profile mapping to indices
-        self.risk_profile_mapping = {
-            'AAA': 0, 'AA': 1, 'A': 2, 'A1': 3, 'A2': 4, 'B': 5, 
-            'C1': 6, 'C2': 7, 'C3': 8, 'D1': 9, 'D2': 10, 'D3': 11,
-            'E1': 12, 'E2': 13, 'E3': 14, 'E4': 15, 'E5': 16, 
-            'F1': 17, 'F2': 18, 'F3': 19, 'F4': 20,
-            'B_SB': 21, 'C1_SB': 22, 'C2_SB': 23, 'E5_SB': 24, 'Z': 25
-        }
+        # Use shared risk profile mapping
+        self.risk_profile_mapping = RISK_PROFILE_MAPPING
 
         # Caches for repeated access
         self._customers_cache = None

--- a/core/data_loader_dev.py
+++ b/core/data_loader_dev.py
@@ -9,6 +9,7 @@ import logging
 from core.logging_config import setup_logging
 from pathlib import Path
 from core import cache_utils
+from core.risk_profiles import RISK_PROFILE_MAPPING
 
 # Set up logging
 setup_logging(logging.INFO)
@@ -21,15 +22,8 @@ class DevelopmentDataLoader:
         # re-read the CSV files.  These are populated on first use.
         self._customers_cache = None
         self._inventory_cache = None
-        # Risk profile mapping to indices
-        self.risk_profile_mapping = {
-            'Low': 0, 'Medium': 1, 'High': 2,
-            'AAA': 0, 'AA': 1, 'A': 2, 'A1': 3, 'A2': 4, 'B': 5, 
-            'C1': 6, 'C2': 7, 'C3': 8, 'D1': 9, 'D2': 10, 'D3': 11,
-            'E1': 12, 'E2': 13, 'E3': 14, 'E4': 15, 'E5': 16, 
-            'F1': 17, 'F2': 18, 'F3': 19, 'F4': 20,
-            'B_SB': 21, 'C1_SB': 22, 'C2_SB': 23, 'E5_SB': 24, 'Z': 25
-        }
+        # Use shared risk profile mapping
+        self.risk_profile_mapping = RISK_PROFILE_MAPPING
 
     def create_sample_inventory(self):
         """Create sample inventory data for development"""

--- a/core/risk_profiles.py
+++ b/core/risk_profiles.py
@@ -1,0 +1,11 @@
+# Shared risk profile mapping used across data loaders
+RISK_PROFILE_MAPPING = {
+    'Low': 0,
+    'Medium': 1,
+    'High': 2,
+    'AAA': 0, 'AA': 1, 'A': 2, 'A1': 3, 'A2': 4, 'B': 5,
+    'C1': 6, 'C2': 7, 'C3': 8, 'D1': 9, 'D2': 10, 'D3': 11,
+    'E1': 12, 'E2': 13, 'E3': 14, 'E4': 15, 'E5': 16,
+    'F1': 17, 'F2': 18, 'F3': 19, 'F4': 20,
+    'B_SB': 21, 'C1_SB': 22, 'C2_SB': 23, 'E5_SB': 24, 'Z': 25,
+}


### PR DESCRIPTION
## Summary
- consolidate risk profile mapping in `core.risk_profiles`
- import the shared mapping in both data loader implementations

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ce89a750832284b1544739d9f82a