### PR TITLE
Improve scenario metric docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,12 @@ Key configuration parameters:
  - GPS Monthly Fee: 350 MXN
  - Max Combinations: 1,000
  - Early Stop Offers: 100
- - Minimum NPV Threshold: 5,000 MXN
- - See [docs/range_optimization.md](docs/range_optimization.md) for full details.
+- Minimum NPV Threshold: 5,000 MXN
+- See [docs/range_optimization.md](docs/range_optimization.md) for full details.
+
+### Scenario Analysis Metrics
+For an explanation of how offer counts and portfolio NPV are extrapolated from a customer sample see
+[docs/scenario_metrics.md](docs/scenario_metrics.md).
 
 ## API Endpoints
 

--- a/core/scenarios.py
+++ b/core/scenarios.py
@@ -71,8 +71,8 @@ def run_scenario_analysis(config: Dict, customers_df: DataFrame, inventory_df: D
         avg_offers_per_customer = total_offers / processed_customers if processed_customers > 0 else 0
         avg_npv_per_offer = total_npv / total_offers if total_offers > 0 else 0
 
-        extrapolated_total_offers = int(avg_offers_per_customer * total_customers)
-        extrapolated_total_npv = int(avg_npv_per_offer * extrapolated_total_offers)
+        extrapolated_total_offers = int(round(avg_offers_per_customer * total_customers))
+        extrapolated_total_npv = int(round(avg_npv_per_offer * extrapolated_total_offers))
 
         execution_time = time.time() - start_time
 
@@ -87,7 +87,7 @@ def run_scenario_analysis(config: Dict, customers_df: DataFrame, inventory_df: D
             },
             "actual_metrics": {
                 "total_offers": extrapolated_total_offers,
-                "average_npv_per_offer": int(avg_npv_per_offer),
+                "average_npv_per_offer": round(avg_npv_per_offer, 2),
                 "total_portfolio_npv": extrapolated_total_npv,
                 "offers_per_customer": round(avg_offers_per_customer, 1),
                 "tier_distribution": offers_by_tier,

--- a/docs/scenario_metrics.md
+++ b/docs/scenario_metrics.md
@@ -1,0 +1,26 @@
+# Scenario Analysis Metrics
+
+The scenario analysis mode uses a small sample of customers to estimate how the engine might perform across the full portfolio.
+The process samples up to 100 customers, generates offers for each one and then extrapolates the metrics.
+
+## Calculation Steps
+
+1. **Average Offers per Customer**
+   ```
+   avg_offers_per_customer = total_offers / processed_customers
+   ```
+   where `total_offers` is the number of offers produced for the sample and `processed_customers` excludes any that failed.
+2. **Average NPV per Offer**
+   ```
+   avg_npv_per_offer = total_npv / total_offers
+   ```
+3. **Portfolio Estimates**
+   ```
+   estimated_total_offers = avg_offers_per_customer * total_customers
+   estimated_portfolio_npv = avg_npv_per_offer * estimated_total_offers
+   ```
+   `total_customers` is the count of all eligible customers in the dataset.
+
+Because these figures are derived from a small sample, the extrapolated totals can be unrealistic if the sample is not representative
+or if an unusually high number of offers is generated. Inspect the raw sample metrics and adjust the engine configuration
+when numbers appear out of range.


### PR DESCRIPTION
## Summary
- refine extrapolation rounding in `run_scenario_analysis`
- document how scenario metrics are calculated
- link new documentation from README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ce90c0d4832287beb9c4a681aee6