### PR TITLE
Update financed loan amount

### DIFF
--- a/core/calculator.py
+++ b/core/calculator.py
@@ -48,7 +48,10 @@ def generate_amortization_table(offer_details: dict) -> list[dict]:
     monthly_rate_i = rate / 12
     monthly_rate_p = (rate * IVA_RATE) / 12
 
-    financed_main = loan_amount
+    # "loan_amount" now represents the total financed amount including
+    # service fee, Kavak Total, and the first insurance cycle. Extract the
+    # main principal portion for the amortization buckets.
+    financed_main = loan_amount - service_fee - kavak_total - insurance_amt
     financed_sf = service_fee
     financed_kt = kavak_total
 

--- a/core/engine.py
+++ b/core/engine.py
@@ -674,6 +674,11 @@ def _generate_single_offer(
         ),
     )
 
+    # 7. Total financed amount (main loan + financed fees)
+    total_financed = (
+        loan_amount_needed + service_fee_amt + kavak_total_amt + insurance_amt
+    )
+
     # 7. Down payment check using effective equity
     required_dp_pct = DOWN_PAYMENT_TABLE.loc[customer["risk_profile_index"], term]
     if effective_equity < car["sales_price"] * required_dp_pct:
@@ -716,7 +721,7 @@ def _generate_single_offer(
         "term": term,
         "monthly_payment": actual_monthly_payment,
         "payment_delta": payment_delta,
-        "loan_amount": loan_amount_needed,
+        "loan_amount": total_financed,
         "effective_equity": effective_equity,
         "cxa_amount": cxa_amount,
         "service_fee_amount": service_fee_amt,
@@ -724,7 +729,7 @@ def _generate_single_offer(
         "insurance_amount": insurance_amt,
         "gps_install_fee": gps_install_with_iva,
         "gps_monthly_fee": gps_monthly_with_iva,
-        "npv": calculate_final_npv(loan_amount_needed, final_rate, term),
+        "npv": calculate_final_npv(total_financed, final_rate, term),
         "fees_applied": fees_config,
         "interest_rate": final_rate,
     }

--- a/core/test_gps_financing.py
+++ b/core/test_gps_financing.py
@@ -31,10 +31,18 @@ def test_gps_installation_not_financed():
 
     gps_install_with_iva = GPS_INSTALLATION_FEE * IVA_RATE
     cxa_amount = car["sales_price"] * fees["cxa_pct"]
-    expected_loan = car["sales_price"] - (
+    expected_base_loan = car["sales_price"] - (
         customer["vehicle_equity"] + fees["cac_bonus"] - cxa_amount - gps_install_with_iva
     )
-    assert offer["loan_amount"] == pytest.approx(expected_loan)
-    assert offer["loan_amount"] + offer["effective_equity"] == pytest.approx(
-        car["sales_price"]
-    )
+    expected_total_financed = expected_base_loan + fees["service_fee_pct"] * car["sales_price"] + fees["kavak_total_amount"] + fees["insurance_amount"]
+
+    assert offer["loan_amount"] == pytest.approx(expected_total_financed)
+
+    # Verify GPS installation is not financed: removing financed fees should equal car price
+    assert (
+        offer["loan_amount"]
+        - offer["service_fee_amount"]
+        - offer["kavak_total_amount"]
+        - offer["insurance_amount"]
+        + offer["effective_equity"]
+    ) == pytest.approx(car["sales_price"])


### PR DESCRIPTION
## Summary
- include financed fees when storing loan_amount
- use total financed amount when calculating NPV
- adapt amortization table to new loan amount definition
- update GPS financing test

## Testing
- `pytest core/test_gps_financing.py::test_gps_installation_not_financed -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d81ac58883229402539ced8fb5df