### PR TITLE
Add financed components to NPV

### DIFF
--- a/core/engine.py
+++ b/core/engine.py
@@ -724,7 +724,14 @@ def _generate_single_offer(
         "insurance_amount": insurance_amt,
         "gps_install_fee": gps_install_with_iva,
         "gps_monthly_fee": gps_monthly_with_iva,
-        "npv": calculate_final_npv(loan_amount_needed, final_rate, term),
+        "npv": calculate_final_npv(
+            loan_amount_needed,
+            final_rate,
+            term,
+            service_fee_amt,
+            insurance_amt,
+            kavak_total_amt,
+        ),
         "fees_applied": fees_config,
         "interest_rate": final_rate,
     }

--- a/core/test_npv.py
+++ b/core/test_npv.py
@@ -1,0 +1,33 @@
+import numpy_financial as npf
+import pytest
+
+from core.calculator import calculate_final_npv, generate_amortization_table
+from core.config import IVA_RATE
+
+
+def test_calculate_final_npv_matches_amortization():
+    details = {
+        "loan_amount": 100000.0,
+        "term": 24,
+        "interest_rate": 0.2,
+        "service_fee_amount": 5000.0,
+        "kavak_total_amount": 10000.0,
+        "insurance_amount": 12000.0,
+        "gps_monthly_fee": 0.0,
+    }
+
+    table = generate_amortization_table(details)
+    monthly_rate_p = (details["interest_rate"] * IVA_RATE) / 12
+    interest_stream = [row["interest"] for row in table]
+    expected = npf.npv(monthly_rate_p, [0] + interest_stream)
+
+    calculated = calculate_final_npv(
+        details["loan_amount"],
+        details["interest_rate"],
+        details["term"],
+        details["service_fee_amount"],
+        details["insurance_amount"],
+        details["kavak_total_amount"],
+    )
+
+    assert calculated == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- include service fee, insurance and Kavak Total when computing NPV
- update offer generation to pass the additional values
- validate NPV calculation with new unit test

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d7fe39348322a54592d318ac45f3