### PR TITLE
Fix scenario runner duplicate processing

### DIFF
--- a/core/scenarios.py
+++ b/core/scenarios.py
@@ -73,6 +73,16 @@ def run_scenario_analysis(
         else:
             customer_sample = customers_df
 
+        # Ensure each customer is processed only once
+        if "customer_id" in customer_sample.columns:
+            before_dedup = len(customer_sample)
+            customer_sample = customer_sample.drop_duplicates(subset="customer_id")
+            after_dedup = len(customer_sample)
+            if after_dedup < before_dedup:
+                logger.debug(
+                    f"Removed {before_dedup - after_dedup} duplicate customers before processing"
+                )
+
         # Run engine for each customer
         for _, customer in customer_sample.iterrows():
             try:


### PR DESCRIPTION
## Summary
- ensure each customer ID is only processed once during scenario analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856fb57ecd483228a2b5c5a939058e3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved scenario analysis by ensuring each customer is processed only once, eliminating duplicate customer entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->