### PR TITLE
Refactor FastAPI setup with app factory

### DIFF
--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Literal, Callable, Optional
+import logging
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from core.logging_config import setup_logging
+
+
+def create_app(
+    mode: Literal["prod", "dev"] = "prod",
+    *,
+    lifespan: Optional[Callable] = None,
+) -> FastAPI:
+    """Application factory returning a configured :class:`FastAPI` instance."""
+
+    setup_logging(logging.INFO)
+
+    if mode == "dev":
+        title = "Trade-Up Engine - Development"
+        description = "Development version optimized for virtual agents"
+        version = "1.0.0-dev"
+        from core.data_loader_dev import dev_data_loader as loader
+    else:
+        title = "Kavak Trade-Up Engine"
+        description = "API and Web Dashboard for generating vehicle upgrade offers."
+        version = "1.0.0"
+        from core.data_loader import data_loader as loader
+
+    app = FastAPI(title=title, description=description, version=version, lifespan=lifespan)
+
+    # Static files and templates used by both modes
+    app.mount("/static", StaticFiles(directory="app/static"), name="static")
+    templates = Jinja2Templates(directory="app/templates")
+    app.state.templates = templates
+
+    # Store the selected data loader for use elsewhere
+    app.state.data_loader = loader
+
+    if mode == "dev":
+        # Development API routes
+        from app.api.routes import router as api_router
+        app.include_router(api_router, prefix="/api")
+
+    return app


### PR DESCRIPTION
## Summary
- centralize FastAPI creation in `app/app_factory.py`
- switch `main.py` and `main_dev.py` to use the new factory
- keep mode-specific configuration via a `create_app()` parameter

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856fb706c388322adbdbe422ab6a31e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Centralized application setup using a factory function for consistent configuration across production and development environments.
	- App initialization, static file mounting, template configuration, and data loader setup are now managed within the factory, simplifying main application files.
	- Development and production modes are now distinguished via a single parameter, streamlining environment-specific configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->