### PR TITLE
Rename Redis status helper

### DIFF
--- a/core/cache_utils.py
+++ b/core/cache_utils.py
@@ -37,17 +37,6 @@ CUSTOMER_CACHE_TTL = int(os.getenv("CUSTOMER_CACHE_TTL", 86400))
 INVENTORY_CACHE_TTL = int(os.getenv("INVENTORY_CACHE_TTL", 86400))
 
 
-def redis_status() -> bool:
-    """Return True if Redis is connected."""
-    if _redis_client is None:
-        return False
-    try:
-        _redis_client.ping()
-        return True
-    except Exception:
-        return False
-
-
 def compute_config_hash(config: dict) -> str:
     """Create a stable hash for a config dictionary."""
     try:
@@ -132,7 +121,7 @@ def set_cached_customers(df):
     _set("customers", df, CUSTOMER_CACHE_TTL)
 
 
-def redis_status() -> str:
+def get_redis_status() -> str:
     """Return a simple status string for the Redis connection."""
     if not REDIS_AVAILABLE:
         return "redis library missing"

--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ async def lifespan(app: FastAPI):
         "inventory_data.csv": csv_readable(Path("inventory_data.csv")),
     }
 
-    checks["redis"] = cache_utils.redis_status()
+    checks["redis"] = cache_utils.get_redis_status()
     logger.info("🔌 Redis status: %s", checks["redis"])
 
     # Persist checks for the /health endpoint
@@ -403,7 +403,7 @@ async def health_check():
             "customer_data.csv": Path("customer_data.csv").exists(),
             "inventory_data.csv": Path("inventory_data.csv").exists(),
         },
-        "redis": cache_utils.redis_status(),
+        "redis": cache_utils.get_redis_status(),
         "startup": getattr(app.state, "startup_checks", {}),
     }
 

--- a/main_dev.py
+++ b/main_dev.py
@@ -16,7 +16,7 @@ from fastapi.responses import HTMLResponse
 import uvicorn
 import logging
 from core.logging_config import setup_logging
-from core.cache_utils import redis_status
+from core.cache_utils import get_redis_status
 import random
 
 setup_logging(logging.INFO)
@@ -93,7 +93,7 @@ async def health_check():
         "external_calls": "disabled",
         "mock_data": "enabled",
         "data_sources": "CSV and sample data only",
-        "redis_connected": redis_status(),
+        "redis_connected": get_redis_status(),
     }
 
 # Main dashboard


### PR DESCRIPTION
## Summary
- remove obsolete boolean `redis_status`
- rename string-returning helper to `get_redis_status`
- update references in `main.py` and `main_dev.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68570889897c832284b256108555fe46