### PR TITLE
Use REDSHIFT_DATABASE env var

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -20,10 +20,12 @@ Create a `.env` file in the root directory with your Redshift credentials:
 ```bash
 REDSHIFT_HOST=your-redshift-cluster.region.redshift.amazonaws.com
 REDSHIFT_PORT=5439
-REDSHIFT_DB=your_database_name
+REDSHIFT_DATABASE=your_database_name
 REDSHIFT_USER=your_username
 REDSHIFT_PASSWORD=your_password
 ```
+The loader also supports the legacy `REDSHIFT_DB` variable if
+`REDSHIFT_DATABASE` is not provided.
 
 **SQL Query:** The system uses your existing `redshift.sql` query which has been fixed and optimized.
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ pip install -r requirements.txt
 ```bash
 cp env_variables.txt .env
 # Edit .env with your configuration
+# Be sure to set `REDSHIFT_DATABASE` with your database name
+# (`REDSHIFT_DB` is also supported for legacy setups)
 ```
 
 ## Running the Application
@@ -166,7 +168,8 @@ pytest
 
 1. **Missing `.env` or incorrect Redshift credentials**
    - Ensure the `.env` file exists in the project root.
-   - Double-check `REDSHIFT_HOST`, `REDSHIFT_USER`, `REDSHIFT_PASSWORD`, and related values.
+   - Double-check `REDSHIFT_HOST`, `REDSHIFT_DATABASE` (or `REDSHIFT_DB`),
+     `REDSHIFT_USER`, `REDSHIFT_PASSWORD`, and related values.
    - Restart the application and visit `/health` to verify a successful connection.
 2. **File permission issues for configuration or scenario result files**
    - Verify read/write permissions on `engine_config.json` and `scenario_results.json`.

--- a/core/data_loader.py
+++ b/core/data_loader.py
@@ -25,7 +25,7 @@ class DataLoader:
         self.redshift_config = {
             'host': os.getenv('REDSHIFT_HOST'),
             'port': os.getenv('REDSHIFT_PORT', 5439),
-            'database': os.getenv('REDSHIFT_DATABASE'),  # Fixed: was REDSHIFT_DB
+            'database': os.getenv('REDSHIFT_DATABASE') or os.getenv('REDSHIFT_DB'),  # fallback for older env vars
             'user': os.getenv('REDSHIFT_USER'),
             'password': os.getenv('REDSHIFT_PASSWORD')
         }


### PR DESCRIPTION
## Summary
- switch docs from `REDSHIFT_DB` to `REDSHIFT_DATABASE`
- mention the new variable in the README
- allow `core.data_loader.DataLoader` to fall back to legacy `REDSHIFT_DB`

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-bdd schemathesis hypothesis`
- `pytest -q` *(fails: AttributeError: module 'schemathesis' has no attribute 'from_asgi')*

------
https://chatgpt.com/codex/tasks/task_e_6857088abfb48322944f90e6a734e60e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated environment variable references in documentation to clarify usage of `REDSHIFT_DATABASE` and legacy support for `REDSHIFT_DB`.
  - Expanded troubleshooting guidance for Redshift connection issues.

- **Bug Fixes**
  - Improved environment variable handling for Redshift database connections, ensuring compatibility with both `REDSHIFT_DATABASE` and legacy `REDSHIFT_DB` variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->