### PR TITLE
Improve accessibility for modals and inputs

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1813,3 +1813,10 @@ h1, h2, h3, h4, h5, h6 {
     /* These styles were refactored or are already defined elsewhere */
     /* This empty rule block is to explicitly show they were considered */
 }
+
+/* Accessible focus outlines */
+button:focus,
+a:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -43,6 +43,9 @@ function setupModals() {
         const modal = document.createElement('div');
         modal.id = 'amortization-modal';
         modal.className = 'modal';
+        modal.setAttribute('role', 'dialog');
+        modal.setAttribute('aria-modal', 'true');
+        modal.setAttribute('aria-label', 'Amortization schedule');
         modal.style.display = 'none';
         modal.innerHTML = `
             <div class="modal-content">
@@ -59,6 +62,9 @@ function setupModals() {
         const modal = document.createElement('div');
         modal.id = 'generic-breakdown-modal';
         modal.className = 'modal';
+        modal.setAttribute('role', 'dialog');
+        modal.setAttribute('aria-modal', 'true');
+        modal.setAttribute('aria-labelledby', 'generic-breakdown-title');
         modal.style.display = 'none';
         modal.innerHTML = `
             <div class="modal-content">

--- a/app/templates/customer_view.html
+++ b/app/templates/customer_view.html
@@ -45,7 +45,7 @@
                 <option value="{{ customer.customer_id }}" selected>Customer {{ customer.customer_id }}</option>
             </select>
         </div>
-        <select id="mode-select" style="margin-right:10px;">
+        <select id="mode-select" style="margin-right:10px;" aria-label="Engine mode">
             <option value="current">Current Mode</option>
             <option value="default">Default</option>
             <option value="custom">Custom</option>

--- a/app/templates/global_config.html
+++ b/app/templates/global_config.html
@@ -146,7 +146,7 @@
     </div>
 
     <!-- Simple Loading Modal for blocking actions -->
-    <div id="config-loading-modal" class="loading-modal" style="display: none;">
+    <div id="config-loading-modal" class="loading-modal" role="dialog" aria-modal="true" aria-labelledby="loading-modal-title" aria-describedby="loading-modal-message" style="display: none;">
         <div class="loading-modal-content">
             <div class="spinner"></div>
             <h3 id="loading-modal-title">Processing...</h3>


### PR DESCRIPTION
## Summary
- add ARIA label for mode select dropdown
- mark loading modal and JS-generated modals with `role="dialog"` and `aria-modal="true"`
- ensure focus outlines for links and buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6857088f57e483229c522f1a9fac568a