### PR TITLE
Implement paginated customers API

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ For an explanation of how offer counts and portfolio NPV are extrapolated from a
 
 ## API Endpoints
 
-- `/api/customers` - List all customers
+- `/api/customers` - List customers. Optional query params: `page` (1-indexed) and `limit` (items per page).
 - `/api/generate-offers` - Generate trade-up offers
 - `/api/save-config` - Save engine configuration
 - `/customer/{customer_id}` - View customer details

--- a/main.py
+++ b/main.py
@@ -491,11 +491,23 @@ def amortization_table(offer: Dict):
 
 
 @app.get("/api/customers", tags=["Customers"])
-def get_all_customers():
-    """Returns a list of all customers."""
+def get_all_customers(page: int = 1, limit: int = 100):
+    """Return a paginated list of customers and the total count."""
+
     if customers_df.empty:
-        return []
-    return customers_df.to_dict("records")
+        return {"customers": [], "total": 0}
+
+    # Sanitize values
+    page = max(page, 1)
+    limit = max(limit, 1)
+
+    start = (page - 1) * limit
+    end = start + limit
+
+    subset = customers_df.iloc[start:end].to_dict("records")
+    total = len(customers_df)
+
+    return {"customers": subset, "total": total}
 
 
 @app.get("/api/inventory", tags=["Inventory"])


### PR DESCRIPTION
## Summary
- add `page` and `limit` parameters to `/api/customers`
- implement pagination logic and include total count in response
- update customer list JS to load pages on scroll
- adjust dropdown fetch for new API
- document new query parameters in README

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-bdd schemathesis hypothesis`
- `pytest -q` *(fails: AttributeError: module 'schemathesis' has no attribute 'from_asgi')*

------
https://chatgpt.com/codex/tasks/task_e_6857088b8f148322b16111553ee03ca3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced infinite scrolling for the customer list, allowing customers to load incrementally as you scroll.
	- The customer list now displays the total number of customers.

- **Bug Fixes**
	- Improved error handling when loading customer data fails.

- **Documentation**
	- Updated the API documentation to clarify pagination options for listing customers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->