### PR TITLE
Restore calculate_npv helper

### DIFF
--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,13 +1,14 @@
 """Trade-Up Engine - Core calculation modules"""
 
 from .basic_matcher import basic_matcher
-from .calculator import generate_amortization_table
+from .calculator import calculate_npv, generate_amortization_table
 from .payment_utils import calculate_monthly_payment, calculate_final_npv
 from .smart_search import smart_search_engine
 
 __all__ = [
     'basic_matcher',
     'calculate_final_npv',
+    'calculate_npv',
     'generate_amortization_table',
     'calculate_monthly_payment',
     'smart_search_engine'

--- a/engine/calculator.py
+++ b/engine/calculator.py
@@ -3,6 +3,30 @@ from config.config import IVA_RATE
 from .payment_utils import calculate_payment_components, calculate_final_npv
 
 
+def calculate_npv(offer: dict) -> float:
+    """Legacy helper to compute NPV of interest income.
+
+    Args:
+        offer: Dictionary containing at least ``total_financed`` (or ``loan_amount``),
+            ``interest_rate`` and ``term`` keys.
+
+    Returns:
+        Calculated NPV value as ``float``.
+    """
+    loan_amount = float(
+        offer.get("total_financed")
+        or offer.get("loan_amount")
+        or 0.0
+    )
+    interest_rate = float(offer.get("interest_rate", 0.0))
+    term_months = int(offer.get("term", 0))
+
+    if loan_amount <= 0 or term_months <= 0:
+        return 0.0
+
+    return calculate_final_npv(loan_amount, interest_rate, term_months)
+
+
 def generate_amortization_table(offer_details: dict) -> list[dict]:
     """. 
     Generate month-by-month amortization table using the EXACT audited logic.


### PR DESCRIPTION
## Summary
- add a legacy `calculate_npv` helper
- re-export `calculate_npv` in `engine.__init__`

## Testing
- `pytest -q` *(fails: AssertionError, KeyError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68616701ec6483228d5641b47ca2ffcc